### PR TITLE
Structure Test Framework

### DIFF
--- a/check_if_image_tag_exists/cloudbuild.yaml
+++ b/check_if_image_tag_exists/cloudbuild.yaml
@@ -7,4 +7,5 @@ steps:
     id: BUILD
   - name: gcr.io/gcp-runtimes/structure_test
     args: '%IMAGE%'
+    id: STRUCTURE_TEST
 images: ['%IMAGE%']

--- a/check_if_image_tag_exists/cloudbuild.yaml
+++ b/check_if_image_tag_exists/cloudbuild.yaml
@@ -1,16 +1,10 @@
 steps:
   - name: gcr.io/gcp-runtimes/check_if_tag_exists
-    args:
-      - 'python'
-      - '/main.py'
-      - '--image=%IMAGE%'
+    args: ['python', '/main.py', '--image=%IMAGE%']
     id: CHECK_TAG
-  - name: gcr.io/gcp-runtimes/structure_tests
-    id: TEST
   - name: gcr.io/cloud-builders/docker
-    args:
-      - 'build'
-      - '--tag=%IMAGE%'
-      - '.'
+    args: ['build', '--tag=%IMAGE%', '.']
     id: BUILD
+  - name: gcr.io/gcp-runtimes/structure_test
+    args: '%IMAGE%'
 images: ['%IMAGE%']

--- a/check_if_image_tag_exists/cloudbuild.yaml
+++ b/check_if_image_tag_exists/cloudbuild.yaml
@@ -1,10 +1,12 @@
 steps:
-  - name: gcr.io/gcp-runtimes/check_if_tag_exists:latest
+  - name: gcr.io/gcp-runtimes/check_if_tag_exists
     args:
       - 'python'
       - '/main.py'
       - '--image=%IMAGE%'
     id: CHECK_TAG
+  - name: gcr.io/gcp-runtimes/structure_tests
+    id: TEST
   - name: gcr.io/cloud-builders/docker
     args:
       - 'build'

--- a/check_if_image_tag_exists/structure_test.json
+++ b/check_if_image_tag_exists/structure_test.json
@@ -1,5 +1,19 @@
 {
 	"commands": [
+		{
+			"name": "uname",
+			"command": "uname",
+			"flags": "-s",
+			"expectedOutput": ["Linux\n"],
+			"expectedError": [""]
+		},
+		{
+			"name": "broken uname",
+			"command": "uname",
+			"flags": "-s -asdfd",
+			"expectedOutput": [],
+			"expectedError": [".*invalid option.*"]
+		}
 	],
 	"file_existence": [
 		{

--- a/check_if_image_tag_exists/structure_test.json
+++ b/check_if_image_tag_exists/structure_test.json
@@ -1,0 +1,17 @@
+{
+	"commands": [
+	],
+	"file_existence": [
+		{
+			"name": "Root",
+			"filePath": "/",
+			"shouldExist": true
+		},{
+			"name": "Fake file",
+			"filePath": "/foo/bar",
+			"shouldExist": false
+		}
+	],
+	"file_contents": [
+	]
+}

--- a/check_if_image_tag_exists/structure_test.json
+++ b/check_if_image_tag_exists/structure_test.json
@@ -12,7 +12,7 @@
 			"command": "uname",
 			"flags": "-s -asdfd",
 			"expectedOutput": [],
-			"expectedError": [".*invalid option.*"]
+			"expectedError": [".*[invalid | unrecognized].*"]
 		}
 	],
 	"file_existence": [
@@ -28,14 +28,5 @@
 			"shouldExist": false
 		}
 	],
-	"file_contents": [
-		{
-			"name": "test file",
-			"path": "/tmp/test.txt",
-			"expectedContents": [
-				".*abc.*",
-				".*[^123].*"
-			]
-		}
-	]
+	"file_contents": []
 }

--- a/check_if_image_tag_exists/structure_test.json
+++ b/check_if_image_tag_exists/structure_test.json
@@ -15,5 +15,13 @@
 		}
 	],
 	"file_contents": [
+		{
+			"name": "test file",
+			"path": "/tmp/test.txt",
+			"expectedContents": [
+				".*abc.*",
+				".*[^123].*"
+			]
+		}
 	]
 }

--- a/check_if_image_tag_exists/structure_test.json
+++ b/check_if_image_tag_exists/structure_test.json
@@ -4,11 +4,13 @@
 	"file_existence": [
 		{
 			"name": "Root",
-			"filePath": "/",
+			"path": "/",
+			"isDirectory": true,
 			"shouldExist": true
 		},{
 			"name": "Fake file",
-			"filePath": "/foo/bar",
+			"path": "/foo/bar",
+			"isDirectory": false,
 			"shouldExist": false
 		}
 	],

--- a/structure_tests/Dockerfile
+++ b/structure_tests/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+COPY structure_test.test /structure_test.test
+
+ENTRYPOINT ["/structure_test.test"]

--- a/structure_tests/Dockerfile
+++ b/structure_tests/Dockerfile
@@ -1,5 +1,6 @@
-FROM scratch
+FROM gcr.io/cloud-builders/docker
 
-COPY structure_test.test /structure_test.test
+COPY structure_test /test/structure_test
+COPY run.sh /run.sh
 
-ENTRYPOINT ["/structure_test.test"]
+ENTRYPOINT ["/run.sh"]

--- a/structure_tests/cloudbuild.yaml
+++ b/structure_tests/cloudbuild.yaml
@@ -3,6 +3,6 @@ steps:
           args: ['test', '-c', 'structure_test.go', '-o', '/workspace/structure_test']
           env: ['PROJECT_ROOT=structure_tests']
         - name: gcr.io/cloud-builders/docker
-          args: ['build', '-t', 'gcr.io/nick-cloudbuild/structure_test', '.']
+          args: ['build', '-t', 'gcr.io/gcp-runtimes/structure_test', '.']
 images:
-        - 'gcr.io/nick-cloudbuild/structure_test'
+        - 'gcr.io/gcp-runtimes/structure_test'

--- a/structure_tests/cloudbuild.yaml
+++ b/structure_tests/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+        - name: gcr.io/cloud-builders/go
+          args: ['test', '-c', 'structure_test.go', '-o', '/workspace/structure_test.test']
+
+          env: ['PROJECT_ROOT=structure_tests']
+        - name: gcr.io/cloud-builders/docker
+          args: ['build', '-t', 'gcr.io/gcp-runtimes/structure_test', '.']
+images:
+        - 'gcr.io/gcp-runtimes/structure_test'

--- a/structure_tests/cloudbuild.yaml
+++ b/structure_tests/cloudbuild.yaml
@@ -1,9 +1,8 @@
 steps:
         - name: gcr.io/cloud-builders/go
-          args: ['test', '-c', 'structure_test.go', '-o', '/workspace/structure_test.test']
-
+          args: ['test', '-c', 'structure_test.go', '-o', '/workspace/structure_test']
           env: ['PROJECT_ROOT=structure_tests']
         - name: gcr.io/cloud-builders/docker
-          args: ['build', '-t', 'gcr.io/gcp-runtimes/structure_test', '.']
+          args: ['build', '-t', 'gcr.io/nick-cloudbuild/structure_test', '.']
 images:
-        - 'gcr.io/gcp-runtimes/structure_test'
+        - 'gcr.io/nick-cloudbuild/structure_test'

--- a/structure_tests/run.sh
+++ b/structure_tests/run.sh
@@ -10,4 +10,4 @@ fi
 
 cp /test/* /workspace/
 
-docker run --privileged=true -v /workspace:/workspace $IMAGE_NAME /bin/sh -c "/workspace/structure_test"
+docker run --privileged=true -v /workspace:/workspace "$IMAGE_NAME" /bin/sh -c "/workspace/structure_test"

--- a/structure_tests/run.sh
+++ b/structure_tests/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+export DOCKER_API_VERSION="1.21"
+
+IMAGE_NAME=$1
+if [ -z "$1" ]; then
+  echo "Please provide fully qualified path to image under test."
+  exit 1
+fi
+
+cp /test/* /workspace/
+
+docker run --privileged=true -v /workspace:/workspace $IMAGE_NAME /bin/sh -c "/workspace/structure_test"

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -19,13 +19,14 @@ type CommandTest struct {
 
 type FileExistenceTest struct {
 	Name				string		// name of test
-	FilePath			string 		// file to check existence of
+	Path				string 		// file to check existence of
+	IsDirectory			bool		// whether or not the path points to a directory
 	ShouldExist			bool 		// whether or not the file should exist
 }
 
 type FileContentTest struct {
 	Name				string		// name of test
-	FilePath			string 		// file to check existence of
+	Path				string 		// file to check existence of
 	ExpectedContents	string 		// expected contents of file	
 }
 
@@ -59,11 +60,16 @@ func TestRunCommand(t *testing.T) {
 func TestFileExists(t *testing.T) {
 	for _, tt := range tests.FileExistenceTests {
 		t.Log(tt.Name)
-		output, err := ioutil.ReadDir(tt.FilePath)
+		var err error
+		if (tt.IsDirectory) {
+			_, err = ioutil.ReadDir(tt.Path)
+		} else {
+			_, err = ioutil.ReadFile(tt.Path)
+		}
 		if tt.ShouldExist && err != nil {
-			t.Errorf("File %s should exist but does not! Error: %s", tt.FilePath, output)
+			t.Errorf("File %s should exist but does not!", tt.Path)
 		} else if !tt.ShouldExist && err == nil {
-			t.Errorf("File %s should not exist but does! Error: %s", tt.FilePath, output)
+			t.Errorf("File %s should not exist but does!", tt.Path)
 		}
 	}
 }
@@ -72,9 +78,9 @@ func TestFileExists(t *testing.T) {
 func TestFileContents(t *testing.T) {
 	for _, tt := range tests.FileContentTests {
 		t.Log(tt.Name)
-		actualContents, err := ioutil.ReadFile(tt.FilePath)
+		actualContents, err := ioutil.ReadFile(tt.Path)
 		if err != nil {
-			t.Errorf("Failed to open %s. Error: %s", tt.FilePath, err)
+			t.Errorf("Failed to open %s. Error: %s", tt.Path, err)
 		}
 		if strings.TrimSpace(tt.ExpectedContents) != strings.TrimSpace(string(actualContents[:])) {
 			t.Errorf("Unexpected file contents encountered!\nExpected: %s\nActual: %s", tt.ExpectedContents, string(actualContents[:]))

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -3,11 +3,11 @@ package structure_tests
 import (
 	"io/ioutil"
 	"os/exec"
-	"strings"
 	"testing"
 	"encoding/json"
 	"flag"
 	"log"
+	"regexp"
 )
 
 type CommandTest struct {
@@ -27,7 +27,7 @@ type FileExistenceTest struct {
 type FileContentTest struct {
 	Name				string		// name of test
 	Path				string 		// file to check existence of
-	ExpectedContents	string 		// expected contents of file	
+	ExpectedContents	[]string 	// list of expected contents of file
 }
 
 type StructureTest struct {
@@ -82,8 +82,15 @@ func TestFileContents(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to open %s. Error: %s", tt.Path, err)
 		}
-		if strings.TrimSpace(tt.ExpectedContents) != strings.TrimSpace(string(actualContents[:])) {
-			t.Errorf("Unexpected file contents encountered!\nExpected: %s\nActual: %s", tt.ExpectedContents, string(actualContents[:]))
+		contents := string(actualContents[:])
+		for _, s := range tt.ExpectedContents {
+			r, rErr := regexp.Compile(s)
+			if rErr != nil {
+				t.Errorf("Error compiling regex: %s", rErr)
+			}
+			if !r.MatchString(contents) {
+				t.Errorf("Expected string %s not found in file contents!", s)
+			}
 		}
 	}
 }

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -1,0 +1,100 @@
+package structure_tests
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"testing"
+	"encoding/json"
+	"flag"
+	"log"
+)
+
+type CommandTest struct {
+	Name				string		// name of test
+	Command				string 		// command to run
+	Flags				string 		// optional flags
+	ExpectedOutput		string 		// expected output of running command
+}
+
+type FileExistenceTest struct {
+	Name				string		// name of test
+	FilePath			string 		// file to check existence of
+	ShouldExist			bool 		// whether or not the file should exist
+}
+
+type FileContentTest struct {
+	Name				string		// name of test
+	FilePath			string 		// file to check existence of
+	ExpectedContents	string 		// expected contents of file	
+}
+
+type StructureTest struct {
+	Commands			[]CommandTest		`json:"commands"`
+	FileExistenceTests 	[]FileExistenceTest	`json:"file_existence"`
+	FileContentTests 	[]FileContentTest	`json:"file_contents"`
+}
+
+
+func TestRunCommand(t *testing.T) {
+	for _, tt := range tests.Commands {
+		t.Log(tt.Name)
+		var cmd *exec.Cmd
+		if tt.Flags != "" {
+			cmd = exec.Command(tt.Command, tt.Flags)
+		} else {
+			cmd = exec.Command(tt.Command)
+		}
+		actualOutput, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Errorf("Error running command: %s %s. Error: %s. Output %s.", tt.Command, tt.Flags, err, actualOutput)
+		}
+		if tt.ExpectedOutput != "" && string(actualOutput) != tt.ExpectedOutput {
+			t.Errorf("Unexpected output for command: %s\nExpected: %s\nActual: %s", tt.Command, tt.ExpectedOutput, string(actualOutput))
+		}
+	}
+}
+
+
+func TestFileExists(t *testing.T) {
+	for _, tt := range tests.FileExistenceTests {
+		t.Log(tt.Name)
+		output, err := ioutil.ReadDir(tt.FilePath)
+		if tt.ShouldExist && err != nil {
+			t.Errorf("File %s should exist but does not! Error: %s", tt.FilePath, output)
+		} else if !tt.ShouldExist && err == nil {
+			t.Errorf("File %s should not exist but does! Error: %s", tt.FilePath, output)
+		}
+	}
+}
+
+
+func TestFileContents(t *testing.T) {
+	for _, tt := range tests.FileContentTests {
+		t.Log(tt.Name)
+		actualContents, err := ioutil.ReadFile(tt.FilePath)
+		if err != nil {
+			t.Errorf("Failed to open %s. Error: %s", tt.FilePath, err)
+		}
+		if strings.TrimSpace(tt.ExpectedContents) != strings.TrimSpace(string(actualContents[:])) {
+			t.Errorf("Unexpected file contents encountered!\nExpected: %s\nActual: %s", tt.ExpectedContents, string(actualContents[:]))
+		}
+	}
+}
+
+var configFile string; var tests StructureTest
+func init() {
+	flag.StringVar(&configFile, "config", "/workspace/structure_test.json",
+		"path to the .yaml file containing test definitions.")
+	flag.Parse()
+
+	var err error; var testJson []byte
+	testJson, err = ioutil.ReadFile(configFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	marshalErr := json.Unmarshal(testJson, &tests)
+	if marshalErr != nil {
+		log.Fatal(err)
+	}
+}

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -1,43 +1,42 @@
 package structure_tests
 
 import (
-	"io/ioutil"
-	"os/exec"
-	"testing"
+	"bytes"
 	"encoding/json"
 	"flag"
+	"io/ioutil"
 	"log"
+	"os/exec"
 	"regexp"
-	"bytes"
+	"testing"
 )
 
 type CommandTest struct {
-	Name				string		// name of test
-	Command				string 		// command to run
-	Flags				string 		// optional flags
-	ExpectedOutput		[]string 	// expected output of running command
-	ExpectedError		[]string	// expected error from running command
+	Name           string   // name of test
+	Command        string   // command to run
+	Flags          string   // optional flags
+	ExpectedOutput []string // expected output of running command
+	ExpectedError  []string // expected error from running command
 }
 
 type FileExistenceTest struct {
-	Name				string		// name of test
-	Path				string 		// file to check existence of
-	IsDirectory			bool		// whether or not the path points to a directory
-	ShouldExist			bool 		// whether or not the file should exist
+	Name        string // name of test
+	Path        string // file to check existence of
+	IsDirectory bool   // whether or not the path points to a directory
+	ShouldExist bool   // whether or not the file should exist
 }
 
 type FileContentTest struct {
-	Name				string		// name of test
-	Path				string 		// file to check existence of
-	ExpectedContents	[]string 	// list of expected contents of file
+	Name             string   // name of test
+	Path             string   // file to check existence of
+	ExpectedContents []string // list of expected contents of file
 }
 
 type StructureTest struct {
-	Commands			[]CommandTest		`json:"commands"`
-	FileExistenceTests 	[]FileExistenceTest	`json:"file_existence"`
-	FileContentTests 	[]FileContentTest	`json:"file_contents"`
+	Commands           []CommandTest       `json:"commands"`
+	FileExistenceTests []FileExistenceTest `json:"file_existence"`
+	FileContentTests   []FileContentTest   `json:"file_contents"`
 }
-
 
 func TestRunCommand(t *testing.T) {
 	for _, tt := range tests.Commands {
@@ -81,12 +80,11 @@ func TestRunCommand(t *testing.T) {
 	}
 }
 
-
 func TestFileExists(t *testing.T) {
 	for _, tt := range tests.FileExistenceTests {
 		t.Log(tt.Name)
 		var err error
-		if (tt.IsDirectory) {
+		if tt.IsDirectory {
 			_, err = ioutil.ReadDir(tt.Path)
 		} else {
 			_, err = ioutil.ReadFile(tt.Path)
@@ -98,7 +96,6 @@ func TestFileExists(t *testing.T) {
 		}
 	}
 }
-
 
 func TestFileContents(t *testing.T) {
 	for _, tt := range tests.FileContentTests {
@@ -120,13 +117,16 @@ func TestFileContents(t *testing.T) {
 	}
 }
 
-var configFile string; var tests StructureTest
+var configFile string
+var tests StructureTest
+
 func init() {
 	flag.StringVar(&configFile, "config", "/workspace/structure_test.json",
 		"path to the .yaml file containing test definitions.")
 	flag.Parse()
 
-	var err error; var testJson []byte
+	var err error
+	var testJson []byte
 	testJson, err = ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -53,29 +53,20 @@ func TestRunCommand(t *testing.T) {
 		cmd.Stderr = &errbuf
 
 		err := cmd.Run()
-		oString := outbuf.String()
-		eString := errbuf.String()
+		stdout := outbuf.String()
+		stderr := errbuf.String()
 
+		var errMessage string
 		if err != nil {
 			for _, errStr := range tt.ExpectedError {
-				r, rErr := regexp.Compile(errStr)
-				if rErr != nil {
-					t.Errorf("Error compiling regex: %s", rErr)
-				}
-				if !r.MatchString(eString) {
-					t.Errorf("Expected string %s not found in error!", errStr)
-				}
+				errMessage = "Expected string " + errStr + " not found in error!"
+				compileAndRunRegex(errStr, stderr, t, errMessage)
 			}
 		}
 
 		for _, outStr := range tt.ExpectedOutput {
-			r, rErr := regexp.Compile(outStr)
-			if rErr != nil {
-				t.Errorf("Error compiling regex: %s", rErr)
-			}
-			if !r.MatchString(oString) {
-				t.Errorf("Expected string %s not found in output!", outStr)
-			}
+			errMessage = "Expected string " + outStr + " not found in output!"
+			compileAndRunRegex(outStr, stdout, t, errMessage)
 		}
 	}
 }
@@ -104,17 +95,25 @@ func TestFileContents(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to open %s. Error: %s", tt.Path, err)
 		}
+
 		contents := string(actualContents[:])
+
+		var errMessage string
 		for _, s := range tt.ExpectedContents {
-			r, rErr := regexp.Compile(s)
-			if rErr != nil {
-				t.Errorf("Error compiling regex %s : %s", s, rErr)
-				continue
-			}
-			if !r.MatchString(contents) {
-				t.Errorf("Expected string %s not found in file contents!", s)
-			}
+			errMessage = "Expected string " + s + " not found in file contents!"
+			compileAndRunRegex(s, contents, t, errMessage)
 		}
+	}
+}
+
+func compileAndRunRegex(regex string, base string, t *testing.T, err string) {
+	r, rErr := regexp.Compile(regex)
+	if rErr != nil {
+		t.Errorf("Error compiling regex %s : %s", regex, rErr.Error())
+		return
+	}
+	if !r.MatchString(base) {
+		t.Errorf(err)
 	}
 }
 

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -40,7 +40,7 @@ type StructureTest struct {
 
 func TestRunCommand(t *testing.T) {
 	for _, tt := range tests.Commands {
-		t.Log(tt.Name)
+		t.Logf("COMMAND TEST: %s", tt.Name)
 		var cmd *exec.Cmd
 		if tt.Flags != "" {
 			cmd = exec.Command(tt.Command, tt.Flags)
@@ -82,7 +82,7 @@ func TestRunCommand(t *testing.T) {
 
 func TestFileExists(t *testing.T) {
 	for _, tt := range tests.FileExistenceTests {
-		t.Log(tt.Name)
+		t.Logf("FILE EXISTENCE TEST: %s", tt.Name)
 		var err error
 		if tt.IsDirectory {
 			_, err = ioutil.ReadDir(tt.Path)
@@ -99,7 +99,7 @@ func TestFileExists(t *testing.T) {
 
 func TestFileContents(t *testing.T) {
 	for _, tt := range tests.FileContentTests {
-		t.Log(tt.Name)
+		t.Logf("FILE CONTENT TEST: %s", tt.Name)
 		actualContents, err := ioutil.ReadFile(tt.Path)
 		if err != nil {
 			t.Errorf("Failed to open %s. Error: %s", tt.Path, err)
@@ -108,7 +108,8 @@ func TestFileContents(t *testing.T) {
 		for _, s := range tt.ExpectedContents {
 			r, rErr := regexp.Compile(s)
 			if rErr != nil {
-				t.Errorf("Error compiling regex: %s", rErr)
+				t.Errorf("Error compiling regex %s : %s", s, rErr)
+				continue
 			}
 			if !r.MatchString(contents) {
 				t.Errorf("Expected string %s not found in file contents!", s)


### PR DESCRIPTION
This adds code to build an image, gcr.io/gcp-runtimes/structure_test, which serves as an intermediate cloudbuild step to run structure tests against an image before pushing to a registry. The tests use a json file (defaulting to `/workspace/structure_test.json`, though this can be specified through a flag) containing the test definitions to run against the base image.

@dlorenc @selgamal
