### PR TITLE
Fix the cloudbuild.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
+structure_tests.test
 cloudbuild.yaml

--- a/structure_tests/cloudbuild.yaml
+++ b/structure_tests/cloudbuild.yaml
@@ -1,8 +1,8 @@
 steps:
         - name: gcr.io/cloud-builders/go
-          args: ['test', '-c', 'structure_test.go', '-o', '/workspace/structure_test']
-          env: ['PROJECT_ROOT=structure_tests']
+          args: ['test', '-c', 'github.com/GoogleCloudPlatform/runtimes-common/structure_tests', '-o', '/workspace/structure_test']
+          env: ['PROJECT_ROOT=github.com/GoogleCloudPlatform/runtimes-common']
         - name: gcr.io/cloud-builders/docker
-          args: ['build', '-t', 'gcr.io/gcp-runtimes/structure_test', '.']
+          args: ['build', '-t', 'gcr.io/gcp-runtimes/structure_test', './structure_tests']
 images:
         - 'gcr.io/gcp-runtimes/structure_test'


### PR DESCRIPTION
Note that you now have to run this from the top level directory, like this:

gcloud alpha container builds create . --config=./structure_tests/cloudbuild.yaml