### PR TITLE
allow overriding of base image entrypoint when running structure tests

### DIFF
--- a/structure_tests/run.sh
+++ b/structure_tests/run.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 
+usage() {
+	echo "Usage: $0 [-i <image>] [-c <config>] [-v] [-e <entrypoint>]"
+	exit 1
+}
+
 export DOCKER_API_VERSION="1.21"
 
 export VERBOSE=0
 export CMD_STRING="/workspace/structure_test"
+export ENTRYPOINT="/bin/sh"
 
 while test $# -gt 0; do
 	case "$1" in
@@ -12,8 +18,7 @@ while test $# -gt 0; do
 			if test $# -gt 0; then
 				export IMAGE_NAME=$1
 			else
-				echo "Please provide fully qualified path to image under test."
-				exit 1
+				usage
 			fi
 			shift
 			;;
@@ -21,20 +26,26 @@ while test $# -gt 0; do
 			export VERBOSE=1
 			shift
 			;;
+		--entrypoint|-e)
+			shift
+			if test $# -gt 0; then
+				export ENTRYPOINT=$1
+			else
+				usage
+			fi
+			shift
+			;;
 		--config|-c)
 			shift
 			if test $# -eq 0; then
-				echo "Please provide fully qualified path to config file."
-				exit 1
+				usage
 			else
 				CMD_STRING=$CMD_STRING" --config $1"
 			fi
 			shift
 			;;
 		*)
-			echo "Usage: $0 -i <image> [-c <config>] [-v]"
-			exit 1
-			shift
+			usage
 			;;
 	esac
 done
@@ -42,7 +53,7 @@ done
 cp /test/* /workspace/
 
 if [ $VERBOSE -eq 1 ]; then
-	CMD_STRING=$CMD_STRING" -v"
+	CMD_STRING=$CMD_STRING" -test.v"
 fi
 
-docker run --privileged=true -v /workspace:/workspace "$IMAGE_NAME" /bin/sh -c "$CMD_STRING"
+docker run --privileged=true -v /workspace:/workspace --entrypoint="$ENTRYPOINT" "$IMAGE_NAME" -c "$CMD_STRING"


### PR DESCRIPTION
need this to support running structure tests on images with non-standard entrypoints.

default entrypoint will be `/bin/sh`; we could also totally remove the entrypoint if you guys think that makes more sense (not all images will contain a shell by default).

@dlorenc @sharifelgamal 