### PR TITLE
change command flags JSON field to array of strings. add verbose logging.

### DIFF
--- a/check_if_image_tag_exists/test_config.json
+++ b/check_if_image_tag_exists/test_config.json
@@ -3,14 +3,14 @@
 		{
 			"name": "uname",
 			"command": "uname",
-			"flags": "-s",
+			"flags": ["-s"],
 			"expectedOutput": ["Linux\n"],
 			"expectedError": [""]
 		},
 		{
 			"name": "broken uname",
 			"command": "uname",
-			"flags": "-s -asdfd",
+			"flags": ["-s", "-asdfd"],
 			"expectedOutput": [],
 			"expectedError": [".*[invalid | unrecognized].*"]
 		}

--- a/structure_tests/README.md
+++ b/structure_tests/README.md
@@ -24,7 +24,7 @@ Command tests ensure that certain commands run properly on top of the shell of t
 
 - Name (string, **required**): The name of the test
 - Command (string, **required**): The command to run
-- Flags (string[], *optional*): Optional flags to pass to the command
+- Flags (string[], *optional*): Optional list of flags to pass to the command
 - Expected Output (string[], *optional*): List of regexes that should match the stdout from running the command.
 - Excluded Output (string[], *optional*): List of regexes that should **not** match the stdout from running the command.
 - Expected Error (string[], *optional*): List of regexes that should match the stderr from running the command.
@@ -36,13 +36,13 @@ Example:
 	{
 		"name": "apt-get",
 		"command": "apt-get",
-		"flags": "help",
+		"flags": ["help"],
 		"expectedOutput": [".*Usage.*"],
 		"excludedError": [".*FAIL.*"]
 	},{
 		"name": "apt-get upgrade",
 		"command": "apt-get",
-		"flags": "-qqs upgrade",
+		"flags": ["-qqs", "upgrade"],
 		"excludedOutput": [".*Inst.*Security.* | .*Security.*Inst.*"],
 		"excludedError": [".*Inst.*Security.* | .*Security.*Inst.*"]
 	}

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -13,10 +13,10 @@ import (
 
 func TestRunCommand(t *testing.T) {
 	for _, tt := range tests.CommandTests {
-		validate(t, tt)
+		validateCommandTest(t, tt)
 		var cmd *exec.Cmd
 		if tt.Flags != nil && len(tt.Flags) > 0 {
-			cmd = exec.Command(tt.Command, tt.Flags)
+			cmd = exec.Command(tt.Command, strings.Join(tt.Flags, " "))
 		} else {
 			cmd = exec.Command(tt.Command)
 		}
@@ -56,7 +56,7 @@ func TestRunCommand(t *testing.T) {
 
 func TestFileExists(t *testing.T) {
 	for _, tt := range tests.FileExistenceTests {
-		validate(t, tt)
+		validateFileExistenceTest(t, tt)
 		var err error
 		if tt.IsDirectory {
 			_, err = ioutil.ReadDir(tt.Path)
@@ -73,7 +73,7 @@ func TestFileExists(t *testing.T) {
 
 func TestFileContents(t *testing.T) {
 	for _, tt := range tests.FileContentTests {
-		validate(t, tt)
+		validateFileContentTest(t, tt)
 		actualContents, err := ioutil.ReadFile(tt.Path)
 		if err != nil {
 			t.Errorf("Failed to open %s. Error: %s", tt.Path, err)
@@ -104,37 +104,31 @@ func compileAndRunRegex(regex string, base string, t *testing.T, err string, sho
 	}
 }
 
-func validate(t *testing.T, tt CommandTest) {
-	if tt.Name == nil || tt.Name == "" {
+func validateCommandTest(t *testing.T, tt CommandTest) {
+	if tt.Name == "" {
 		t.Fatalf("Please provide a valid name for every test!")
 	}
-	if tt.Command == nil || tt.Command == "" {
+	if tt.Command == "" {
 		t.Fatalf("Please provide a valid command to run for test %s", tt.Name)
 	}
 	t.Logf("COMMAND TEST: %s", tt.Name)
 }
 
-func validate(t *testing.T, tt FileExistenceTest) {
-	if tt.Name == nil || tt.Name == "" {
+func validateFileExistenceTest(t *testing.T, tt FileExistenceTest) {
+	if tt.Name == "" {
 		t.Fatalf("Please provide a valid name for every test!")
 	}
-	if tt.Path == nil || tt.Path == "" {
+	if tt.Path == "" {
 		t.Fatalf("Please provide a valid file path for test %s", tt.Name)
-	}
-	if tt.IsDirectory == nil {
-		t.Fatalf("Please specify whether %s is a file or a directory in test %s", tt.Path, tt.Name)
-	}
-	if tt.ShouldExist == nil {
-		t.Fatalf("Please specify whether file/directory %s should exist in test %s", tt.Path, tt.Name)
 	}
 	t.Logf("FILE EXISTENCE TEST: %s", tt.Name)
 }
 
-func validate(t *testing.T, tt FileContentTest) {
-	if tt.Name == nil || tt.Name == "" {
+func validateFileContentTest(t *testing.T, tt FileContentTest) {
+	if tt.Name == "" {
 		t.Fatalf("Please provide a valid name for every test!")
 	}
-	if tt.Path == nil || tt.Path == "" {
+	if tt.Path == "" {
 		t.Fatalf("Please provide a valid file path for test %s", tt.Name)
 	}
 	t.Logf("FILE CONTENT TEST: %s", tt.Name)

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -16,7 +16,7 @@ func TestRunCommand(t *testing.T) {
 		validateCommandTest(t, tt)
 		var cmd *exec.Cmd
 		if tt.Flags != nil && len(tt.Flags) > 0 {
-			cmd = exec.Command(tt.Command, strings.Join(tt.Flags, " "))
+			cmd = exec.Command(tt.Command, tt.Flags...)
 		} else {
 			cmd = exec.Command(tt.Command)
 		}
@@ -32,7 +32,13 @@ func TestRunCommand(t *testing.T) {
 		}
 
 		stdout := outbuf.String()
+		if stdout != "" {
+			t.Logf("stdout: %s", stdout)
+		}
 		stderr := errbuf.String()
+		if stderr != "" {
+			t.Logf("stderr: %s", stderr)
+		}
 
 		for _, errStr := range tt.ExpectedError {
 			errMsg := fmt.Sprintf("Expected string '%s' not found in error!", errStr)

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -13,9 +13,9 @@ import (
 
 func TestRunCommand(t *testing.T) {
 	for _, tt := range tests.CommandTests {
-		t.Logf("COMMAND TEST: %s", tt.Name)
+		validate(t, tt)
 		var cmd *exec.Cmd
-		if tt.Flags != "" {
+		if tt.Flags != nil && len(tt.Flags) > 0 {
 			cmd = exec.Command(tt.Command, tt.Flags)
 		} else {
 			cmd = exec.Command(tt.Command)
@@ -56,7 +56,7 @@ func TestRunCommand(t *testing.T) {
 
 func TestFileExists(t *testing.T) {
 	for _, tt := range tests.FileExistenceTests {
-		t.Logf("FILE EXISTENCE TEST: %s", tt.Name)
+		validate(t, tt)
 		var err error
 		if tt.IsDirectory {
 			_, err = ioutil.ReadDir(tt.Path)
@@ -73,7 +73,7 @@ func TestFileExists(t *testing.T) {
 
 func TestFileContents(t *testing.T) {
 	for _, tt := range tests.FileContentTests {
-		t.Logf("FILE CONTENT TEST: %s", tt.Name)
+		validate(t, tt)
 		actualContents, err := ioutil.ReadFile(tt.Path)
 		if err != nil {
 			t.Errorf("Failed to open %s. Error: %s", tt.Path, err)
@@ -102,6 +102,42 @@ func compileAndRunRegex(regex string, base string, t *testing.T, err string, sho
 	if shouldMatch != r.MatchString(base) {
 		t.Errorf(err)
 	}
+}
+
+func validate(t *testing.T, tt CommandTest) {
+	if tt.Name == nil || tt.Name == "" {
+		t.Fatalf("Please provide a valid name for every test!")
+	}
+	if tt.Command == nil || tt.Command == "" {
+		t.Fatalf("Please provide a valid command to run for test %s", tt.Name)
+	}
+	t.Logf("COMMAND TEST: %s", tt.Name)
+}
+
+func validate(t *testing.T, tt FileExistenceTest) {
+	if tt.Name == nil || tt.Name == "" {
+		t.Fatalf("Please provide a valid name for every test!")
+	}
+	if tt.Path == nil || tt.Path == "" {
+		t.Fatalf("Please provide a valid file path for test %s", tt.Name)
+	}
+	if tt.IsDirectory == nil {
+		t.Fatalf("Please specify whether %s is a file or a directory in test %s", tt.Path, tt.Name)
+	}
+	if tt.ShouldExist == nil {
+		t.Fatalf("Please specify whether file/directory %s should exist in test %s", tt.Path, tt.Name)
+	}
+	t.Logf("FILE EXISTENCE TEST: %s", tt.Name)
+}
+
+func validate(t *testing.T, tt FileContentTest) {
+	if tt.Name == nil || tt.Name == "" {
+		t.Fatalf("Please provide a valid name for every test!")
+	}
+	if tt.Path == nil || tt.Path == "" {
+		t.Fatalf("Please provide a valid file path for test %s", tt.Name)
+	}
+	t.Logf("FILE CONTENT TEST: %s", tt.Name)
 }
 
 var configFiles arrayFlags

--- a/structure_tests/types.go
+++ b/structure_tests/types.go
@@ -20,12 +20,12 @@ func (a *arrayFlags) Set(value string) error {
 }
 
 type CommandTest struct {
-	Name           string	// required
-	Command        string	// required
-	Flags          []string	// optional
-	ExpectedOutput []string	// optional
-	ExcludedOutput []string	// optional
-	ExpectedError  []string	// optional
+	Name           string   // required
+	Command        string   // required
+	Flags          []string // optional
+	ExpectedOutput []string // optional
+	ExcludedOutput []string // optional
+	ExpectedError  []string // optional
 	ExcludedError  []string // optional
 }
 

--- a/structure_tests/types.go
+++ b/structure_tests/types.go
@@ -20,27 +20,27 @@ func (a *arrayFlags) Set(value string) error {
 }
 
 type CommandTest struct {
-	Name           string
-	Command        string
-	Flags          string
-	ExpectedOutput []string
-	ExcludedOutput []string
-	ExpectedError  []string
-	ExcludedError  []string // excluded error from running command
+	Name           string	// required
+	Command        string	// required
+	Flags          []string	// optional
+	ExpectedOutput []string	// optional
+	ExcludedOutput []string	// optional
+	ExpectedError  []string	// optional
+	ExcludedError  []string // optional
 }
 
 type FileExistenceTest struct {
-	Name        string // name of test
-	Path        string // file to check existence of
-	IsDirectory bool   // whether or not the path points to a directory
-	ShouldExist bool   // whether or not the file should exist
+	Name        string // required
+	Path        string // required
+	IsDirectory bool   // required
+	ShouldExist bool   // required
 }
 
 type FileContentTest struct {
-	Name             string   // name of test
-	Path             string   // file to check existence of
-	ExpectedContents []string // list of expected contents of file
-	ExcludedContents []string // list of excluded contents of file
+	Name             string   // required
+	Path             string   // required
+	ExpectedContents []string // optional
+	ExcludedContents []string // optional
 }
 
 type StructureTest struct {


### PR DESCRIPTION
this is necessary, since go's exec.Command() doesn't properly handle joined command strings in all cases (couldn't find a bug for this).

since https://github.com/GoogleCloudPlatform/runtimes-common/pull/28 isn't merged yet, we'll need to manually update this in debian's structure tests to match the current schema version.

once https://github.com/GoogleCloudPlatform/runtimes-common/pull/28 is merged, we'll support legacy space-delimited flag strings (assuming the test writers were able to get their tests to pass with them, which isn't possible in all cases).

@dlorenc @sharifelgamal 