### PR TITLE
add simple rake/docker image for running ruby tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.pyc
 structure_tests.test
-cloudbuild.yaml

--- a/check_if_image_tag_exists/.gitignore
+++ b/check_if_image_tag_exists/.gitignore
@@ -1,0 +1,1 @@
+cloudbuild.yaml

--- a/rake/Dockerfile
+++ b/rake/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcr.io/cloud-builders/docker
 
-RUN apk update && apk upgrade && apk --update add ruby-rake ruby-minitest
+RUN apk update && apk upgrade && apk --update add ruby-rake ruby-minitest curl
 
 ENTRYPOINT 'rake'

--- a/rake/Dockerfile
+++ b/rake/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/cloud-builders/docker
+
+RUN apk update && apk upgrade && apk --update add ruby-rake ruby-minitest
+
+ENTRYPOINT 'rake'

--- a/rake/cloudbuild.yaml
+++ b/rake/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args: ['build', '-t', 'gcr.io/gcp-runtimes/rake', '.']
+images:
+  - 'gcr.io/gcp-runtimes/rake'
+  

--- a/rake/cloudbuild.yaml
+++ b/rake/cloudbuild.yaml
@@ -3,4 +3,3 @@ steps:
     args: ['build', '-t', 'gcr.io/gcp-runtimes/rake', '.']
 images:
   - 'gcr.io/gcp-runtimes/rake'
-  

--- a/structure_tests/.gitignore
+++ b/structure_tests/.gitignore
@@ -1,0 +1,1 @@
+cloudbuild.yaml


### PR DESCRIPTION
this will be used to run the Ruby non-structure tests through a container build temporarily while we develop the integration testing framework.

@dlorenc 