### PR TITLE
support for setup/teardown commands in cmd tests

### DIFF
--- a/check_if_image_tag_exists/structure_test.yaml
+++ b/check_if_image_tag_exists/structure_test.yaml
@@ -1,13 +1,11 @@
 commandTests:
 - name:  'uname'
-  command: 'uname'
-  flags: '-s'
+  command: ['uname', '-s']
   expectedError: ['foo']
   expectedOutput: ['Linux\n']
 
 - name:  'broken uname'
-  command: 'uname'
-  flags: '-s -asdf'
+  command: ['uname', '-s', '-asdf']
   expectedError: ['.*[invalid | unrecognized].*']
   expectedOutput: []
 

--- a/structure_tests/README.md
+++ b/structure_tests/README.md
@@ -42,7 +42,7 @@ Example:
 	},{
 		"name": "Custom Node Version",
 		"setup": [["install_node", "v5.9.0"]],
-		"setup": [["install_node", "v6.9.1"]],
+		"teardown": [["install_node", "v6.9.1"]],
 		"command": ["node", "-v"],
   		"expectedOutput": ["v5.9.0\n"]
 	}

--- a/structure_tests/README.md
+++ b/structure_tests/README.md
@@ -23,8 +23,9 @@ Command tests ensure that certain commands run properly on top of the shell of t
 #### Supported Fields:
 
 - Name (string, **required**): The name of the test
-- Command (string, **required**): The command to run
-- Flags (string[], *optional*): Optional list of flags to pass to the command
+- Setup ([][]string, *optional*): A list of commands (each with optional flags) to run before the actual command under test.
+- Teardown ([][]string, *optional*): A list of commands (each with optional flags) to run after the actual command under test.
+- Command ([]string, **required**): The command to run, along with the flags to pass to it.
 - Expected Output (string[], *optional*): List of regexes that should match the stdout from running the command.
 - Excluded Output (string[], *optional*): List of regexes that should **not** match the stdout from running the command.
 - Expected Error (string[], *optional*): List of regexes that should match the stderr from running the command.
@@ -34,17 +35,16 @@ Example:
 ```json
 "commandTests": [
 	{
-		"name": "apt-get",
-		"command": "apt-get",
-		"flags": ["help"],
-		"expectedOutput": [".*Usage.*"],
-		"excludedError": [".*FAIL.*"]
-	},{
 		"name": "apt-get upgrade",
-		"command": "apt-get",
-		"flags": ["-qqs", "upgrade"],
+		"command": ["apt-get", "-qqs", "upgrade"],
 		"excludedOutput": [".*Inst.*Security.* | .*Security.*Inst.*"],
 		"excludedError": [".*Inst.*Security.* | .*Security.*Inst.*"]
+	},{
+		"name": "Custom Node Version",
+		"setup": [["install_node", "v5.9.0"]],
+		"setup": [["install_node", "v6.9.1"]],
+		"command": ["node", "-v"],
+  		"expectedOutput": ["v5.9.0\n"]
 	}
 ]
 ```
@@ -52,8 +52,7 @@ Example:
 ```yaml
 commandTests:
 - name:  'apt-get'
-  command: 'apt-get'
-  flags: 'help'
+  command: ['apt-get', 'help']
   expectedError: ['.*Usage.*']
   excludedError: ['*FAIL.*']
 ```

--- a/structure_tests/build.sh
+++ b/structure_tests/build.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+usage() { echo "Usage: ./build.sh [target_image_path]"; exit 1; }
+
 set -e
 
-export VERSION=$1
+export IMAGE=$1
 
-if [ -z "$1" ]; then
-  echo "Please provide valid version to tag image."
-  exit 1
+if [ -z "$IMAGE" ]; then
+  usage
 fi
 
 envsubst < cloudbuild.yaml.in > cloudbuild.yaml

--- a/structure_tests/cloudbuild.yaml.in
+++ b/structure_tests/cloudbuild.yaml.in
@@ -3,6 +3,6 @@ steps:
           args: ['test', '-c', 'github.com/GoogleCloudPlatform/runtimes-common/structure_tests', '-o', '/workspace/structure_tests/structure_test']
           env: ['PROJECT_ROOT=github.com/GoogleCloudPlatform/runtimes-common']
         - name: gcr.io/cloud-builders/docker
-          args: ['build', '-t', 'gcr.io/gcp-runtimes/structure_test:${VERSION}', './structure_tests']
+          args: ['build', '-t', '${IMAGE}', './structure_tests']
 images:
-        - 'gcr.io/gcp-runtimes/structure_test:${VERSION}'
+        - '${IMAGE}'

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -22,8 +22,7 @@ type CommandTestv1 struct {
 	Name           string
 	Setup          []string
 	Teardown       []string
-	Command        string
-	Flags          []string
+	Command        []string
 	ExpectedOutput []string
 	ExcludedOutput []string
 	ExpectedError  []string
@@ -34,7 +33,7 @@ func validateCommandTestV1(t *testing.T, tt CommandTestv1) {
 	if tt.Name == "" {
 		t.Fatalf("Please provide a valid name for every test!")
 	}
-	if tt.Command == "" {
+	if tt.Command == nil || len(tt.Command) == 0 {
 		t.Fatalf("Please provide a valid command to run for test %s", tt.Name)
 	}
 	t.Logf("COMMAND TEST: %s", tt.Name)

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -20,8 +20,8 @@ import (
 
 type CommandTestv1 struct {
 	Name           string
-	Setup          []string
-	Teardown       []string
+	Setup          [][]string
+	Teardown       [][]string
 	Command        []string
 	ExpectedOutput []string
 	ExcludedOutput []string

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -24,7 +24,6 @@ type CommandTestv1 struct {
 	Teardown       []string
 	Command        string
 	Flags          []string
-	EnvVars        []string
 	ExpectedOutput []string
 	ExcludedOutput []string
 	ExpectedError  []string

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -22,6 +22,7 @@ type CommandTestv1 struct {
 	Name           string
 	Command        string
 	Flags          []string
+	EnvVars        []string
 	ExpectedOutput []string
 	ExcludedOutput []string
 	ExpectedError  []string

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -23,6 +23,7 @@ type CommandTestv1 struct {
 	Setup          []string
 	Teardown       []string
 	Command        string
+	Flags          []string
 	EnvVars        []string
 	ExpectedOutput []string
 	ExcludedOutput []string

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -20,8 +20,9 @@ import (
 
 type CommandTestv1 struct {
 	Name           string
+	Setup          []string
+	Teardown       []string
 	Command        string
-	Flags          []string
 	EnvVars        []string
 	ExpectedOutput []string
 	ExcludedOutput []string

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -39,14 +39,7 @@ func TestAll(t *testing.T) {
 	}
 }
 
-func compileAndRunRegex(rawRegex string, base string, t *testing.T, err string, shouldMatch bool) {
-	// currently a hack to replace PWD in output/error until we figure
-	// out a better way to handle this.
-	value := os.Getenv("PWD")
-	if value == "" {
-		t.Fatalf("Error resolving $PWD")
-	}
-	regex := strings.Replace(rawRegex, "$PWD", value, -1)
+func compileAndRunRegex(regex string, base string, t *testing.T, err string, shouldMatch bool) {
 	r, rErr := regexp.Compile(regex)
 	if rErr != nil {
 		t.Errorf("Error compiling regex %s : %s", regex, rErr.Error())

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -39,7 +39,14 @@ func TestAll(t *testing.T) {
 	}
 }
 
-func compileAndRunRegex(regex string, base string, t *testing.T, err string, shouldMatch bool) {
+func compileAndRunRegex(rawRegex string, base string, t *testing.T, err string, shouldMatch bool) {
+	// currently a hack to replace PWD in output/error until we figure
+	// out a better way to handle this.
+	value := os.Getenv("PWD")
+	if value == "" {
+		t.Fatalf("Error resolving $PWD")
+	}
+	regex := strings.Replace(rawRegex, "$PWD", value, -1)
 	r, rErr := regexp.Compile(regex)
 	if rErr != nil {
 		t.Errorf("Error compiling regex %s : %s", regex, rErr.Error())

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -40,8 +40,12 @@ func (st StructureTestv1) RunCommandTests(t *testing.T) {
 	for _, tt := range st.CommandTests {
 		validateCommandTestV1(t, tt)
 		ProcessCommands(t, tt.Setup)
-		cmdParts := strings.Split(tt.Command, " ")
-		cmd := exec.Command(cmdParts[0], cmdParts[1:]...)
+		var cmd *exec.Cmd
+		if tt.Flags != nil && len(tt.Flags) > 0 {
+			cmd = exec.Command(tt.Command, tt.Flags...)
+		} else {
+			cmd = exec.Command(tt.Command)
+		}
 		t.Logf("Executing: %s", cmd.Args)
 		var outbuf, errbuf bytes.Buffer
 

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -18,9 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"os/exec"
-	"strings"
 	"testing"
 )
 
@@ -99,22 +97,6 @@ func (st StructureTestv1) RunFileContentTests(t *testing.T) {
 	}
 }
 
-// currently a hack to replace PWD in output/error until we figure
-// out a better way to handle this.
-func SubstituteEnvVars(t *testing.T, lists ...*[]string) {
-	env_var := "PWD"
-	value := os.Getenv(env_var)
-	if value == "" {
-		t.Fatalf("Variable %s not found in environment!", env_var)
-	}
-	for _, list := range lists {
-		for i := range *list {
-			str := (*list)[i]
-			(*list)[i] = strings.Replace(str, "$"+env_var, value, -1)
-		}
-	}
-}
-
 func ProcessCommand(t *testing.T, fullCommand []string, checkOutput bool) (string, string) {
 	var cmd *exec.Cmd
 	command := fullCommand[0]
@@ -157,8 +139,6 @@ func ProcessCommand(t *testing.T, fullCommand []string, checkOutput bool) (strin
 }
 
 func CheckOutput(t *testing.T, tt CommandTestv1, stdout string, stderr string) {
-	SubstituteEnvVars(t, &(tt.ExpectedOutput), &(tt.ExcludedOutput), &(tt.ExpectedError), &(tt.ExcludedError))
-
 	for _, errStr := range tt.ExpectedError {
 		errMsg := fmt.Sprintf("Expected string '%s' not found in error!", errStr)
 		compileAndRunRegex(errStr, stderr, t, errMsg, true)

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -18,7 +18,9 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -62,6 +64,8 @@ func (st StructureTestv1) RunCommandTests(t *testing.T) {
 		if stderr != "" {
 			t.Logf("stderr: %s", stderr)
 		}
+
+		SubstituteEnvVars(t, tt.EnvVars, &(tt.ExpectedOutput), &(tt.ExcludedOutput), &(tt.ExpectedError), &(tt.ExcludedError))
 
 		for _, errStr := range tt.ExpectedError {
 			errMsg := fmt.Sprintf("Expected string '%s' not found in error!", errStr)
@@ -118,6 +122,25 @@ func (st StructureTestv1) RunFileContentTests(t *testing.T) {
 		for _, s := range tt.ExcludedContents {
 			errMessage = "Excluded string " + s + " found in file contents!"
 			compileAndRunRegex(s, contents, t, errMessage, false)
+		}
+	}
+}
+
+
+// Given a list of environment variables and a list of lists of strings,
+// retrieve each environment variable's value and replace all occurrences
+// of it in each list of strings provided.
+func SubstituteEnvVars(t *testing.T, vars []string, lists ...*[]string) {
+	for _, env_var := range vars {
+		value := os.Getenv(env_var)
+		if value == "" {
+			t.Fatalf("Variable %s not found in environment!", env_var)
+		}
+		for _, list := range lists {
+			for i := range *list {
+				str := (*list)[i]
+				(*list)[i] = strings.Replace(str, "$"+env_var, value, -1)
+			}
 		}
 	}
 }

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -94,9 +94,17 @@ func (st StructureTestv1) RunFileExistenceTests(t *testing.T) {
 			_, err = ioutil.ReadFile(tt.Path)
 		}
 		if tt.ShouldExist && err != nil {
-			t.Errorf("File %s should exist but does not!", tt.Path)
+			if tt.IsDirectory {
+				t.Errorf("Directory %s should exist but does not!", tt.Path)
+			} else {
+				t.Errorf("File %s should exist but does not!", tt.Path)
+			}
 		} else if !tt.ShouldExist && err == nil {
-			t.Errorf("File %s should not exist but does!", tt.Path)
+			if tt.IsDirectory {
+				t.Errorf("Directory %s should not exist but does!", tt.Path)
+			} else {
+				t.Errorf("File %s should not exist but does!", tt.Path)
+			}
 		}
 	}
 }

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -131,7 +131,6 @@ func (st StructureTestv1) RunFileContentTests(t *testing.T) {
 	}
 }
 
-
 // Given a list of environment variables and a list of lists of strings,
 // retrieve each environment variable's value and replace all occurrences
 // of it in each list of strings provided.

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -41,10 +41,12 @@ func (st StructureTestv1) RunCommandTests(t *testing.T) {
 		validateCommandTestV1(t, tt)
 		ProcessCommands(t, tt.Setup)
 		var cmd *exec.Cmd
-		if tt.Flags != nil && len(tt.Flags) > 0 {
-			cmd = exec.Command(tt.Command, tt.Flags...)
+		command := tt.Command[0]
+		flags := tt.Command[1:]
+		if len(flags) > 0 {
+			cmd = exec.Command(command, flags...)
 		} else {
-			cmd = exec.Command(tt.Command)
+			cmd = exec.Command(command)
 		}
 		t.Logf("Executing: %s", cmd.Args)
 		var outbuf, errbuf bytes.Buffer

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -66,7 +66,7 @@ func (st StructureTestv1) RunCommandTests(t *testing.T) {
 			t.Logf("stderr: %s", stderr)
 		}
 
-		SubstituteEnvVars(t, tt.EnvVars, &(tt.ExpectedOutput), &(tt.ExcludedOutput), &(tt.ExpectedError), &(tt.ExcludedError))
+		SubstituteEnvVars(t, &(tt.ExpectedOutput), &(tt.ExcludedOutput), &(tt.ExpectedError), &(tt.ExcludedError))
 
 		for _, errStr := range tt.ExpectedError {
 			errMsg := fmt.Sprintf("Expected string '%s' not found in error!", errStr)
@@ -135,20 +135,18 @@ func (st StructureTestv1) RunFileContentTests(t *testing.T) {
 	}
 }
 
-// Given a list of environment variables and a list of lists of strings,
-// retrieve each environment variable's value and replace all occurrences
-// of it in each list of strings provided.
-func SubstituteEnvVars(t *testing.T, vars []string, lists ...*[]string) {
-	for _, env_var := range vars {
-		value := os.Getenv(env_var)
-		if value == "" {
-			t.Fatalf("Variable %s not found in environment!", env_var)
-		}
-		for _, list := range lists {
-			for i := range *list {
-				str := (*list)[i]
-				(*list)[i] = strings.Replace(str, "$"+env_var, value, -1)
-			}
+// currently a hack to replace PWD in output/error until we figure
+// out a better way to handle this.
+func SubstituteEnvVars(t *testing.T, lists ...*[]string) {
+	env_var := "PWD"
+	value := os.Getenv(env_var)
+	if value == "" {
+		t.Fatalf("Variable %s not found in environment!", env_var)
+	}
+	for _, list := range lists {
+		for i := range *list {
+			str := (*list)[i]
+			(*list)[i] = strings.Replace(str, "$"+env_var, value, -1)
 		}
 	}
 }

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -136,23 +136,7 @@ func ProcessCommand(t *testing.T, fullCommand []string, checkOutput bool) (strin
 	cmd.Stdout = &outbuf
 	cmd.Stderr = &errbuf
 
-	if err := cmd.Run(); err != nil {
-		if checkOutput {
-			// The test might be designed to run a command that exits with an error.
-			t.Logf("Error running command: %s. Continuing.", err)
-		} else {
-			stdout := outbuf.String()
-			if stdout != "" {
-				t.Logf("stdout: %s", stdout)
-			}
-			stderr := errbuf.String()
-			if stderr != "" {
-				t.Logf("stderr: %s", stderr)
-			}
-			t.Fatalf("Error running setup/teardown command: %s.", err)
-		}
-	}
-
+	err := cmd.Run()
 	stdout := outbuf.String()
 	if stdout != "" {
 		t.Logf("stdout: %s", stdout)
@@ -160,6 +144,14 @@ func ProcessCommand(t *testing.T, fullCommand []string, checkOutput bool) (strin
 	stderr := errbuf.String()
 	if stderr != "" {
 		t.Logf("stderr: %s", stderr)
+	}
+	if err != nil {
+		if checkOutput {
+			// The test might be designed to run a command that exits with an error.
+			t.Logf("Error running command: %s. Continuing.", err)
+		} else {
+			t.Fatalf("Error running setup/teardown command: %s.", err)
+		}
 	}
 	return stdout, stderr
 }


### PR DESCRIPTION
~~**UPDATE**: Adding back the flags field. This would cause a few tests to be impossible to run, so I'll leave it as is for now.~~

**UPDATE 2.0, 11/10/16**: Decided we want to rethink env var substitution. For now, hardcoding in $PWD substitution until we figure out how we want to handle the general case. Additionally, unified the way that normal commands and setup/teardown commands are defined in the config and run in the framework.

This adds support for two new fields in the command tests:
* Setup: []string, a list of commands to run before a command test is run. This provides a lot of flexibility for modifying the environment of the test before running the test itself.
* Teardown: []string, a list of commands to run after a test is complete. Exists to allow reversing anything done in setup commands.

**Note**: instead of adding a new schema version for the removal of the flags, I'm just going to manually change the existing tests (since there are so few of them). I'd prefer to keep things at one schema for as long as we can get away with. These will come in separate PRs.