### PR TITLE
create new StructureTest instance for every file parse to avoid memory overlap

### DIFF
--- a/structure_tests/ext_run.sh
+++ b/structure_tests/ext_run.sh
@@ -6,7 +6,7 @@ CMD_STRING=""
 ENTRYPOINT="./test/structure_test"
 ST_IMAGE="gcr.io/gcp-runtimes/structure_test"
 CONFIG_COUNTER=0
-USAGE_STRING="Usage: $0 [-i <image>] [-c <config>] [-v] [-e <entrypoint>] [-p]"
+USAGE_STRING="Usage: $0 [-i <image>] [-c <config>] [-v] [-e <entrypoint>] [--no-pull]"
 
 CONFIG_DIR=$(pwd)/.cfg
 mkdir -p "$CONFIG_DIR"
@@ -31,7 +31,7 @@ helper() {
 	echo "	-c, --config         path to json/yaml config file"
 	echo "	-v                   display verbose testing output"
 	echo "	-e, --entrypoint     specify custom docker entrypoint for image"
-	echo "	--no-pull            pull latest structure test image"
+	echo "	--no-pull            don't pull latest structure test image"
 	exit 0
 }
 

--- a/structure_tests/ext_run.sh
+++ b/structure_tests/ext_run.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
 VERBOSE=0
+PULL=1
 CMD_STRING=""
 ENTRYPOINT="./test/structure_test"
 ST_IMAGE="gcr.io/gcp-runtimes/structure_test"
 CONFIG_COUNTER=0
+USAGE_STRING="Usage: $0 [-i <image>] [-c <config>] [-v] [-e <entrypoint>] [-p]"
 
 CONFIG_DIR=$(pwd)/.cfg
 mkdir -p "$CONFIG_DIR"
@@ -17,9 +19,20 @@ cleanup() {
 }
 
 usage() {
-	echo "Usage: $0 [-i <image>] [-c <config>] [-v] [-e <entrypoint>]"
+	echo "$USAGE_STRING"
 	cleanup
 	exit 1
+}
+
+helper() {
+	echo "$USAGE_STRING"
+	echo
+	echo "	-i, --image          image to run tests on"
+	echo "	-c, --config         path to json/yaml config file"
+	echo "	-v                   display verbose testing output"
+	echo "	-e, --entrypoint     specify custom docker entrypoint for image"
+	echo "	--no-pull            pull latest structure test image"
+	exit 0
 }
 
 while test $# -gt 0; do
@@ -36,6 +49,13 @@ while test $# -gt 0; do
 		--verbose|-v)
 			VERBOSE=1
 			shift
+			;;
+		--no-pull)
+			PULL=0
+			shift
+			;;
+		--help|-h)
+			helper
 			;;
 		--config|-c)
 			shift
@@ -72,7 +92,10 @@ if [ $VERBOSE -eq 1 ]; then
 	CMD_STRING=$CMD_STRING" -test.v"
 fi
 
-docker pull "$ST_IMAGE"
+if [ $PULL -eq 1 ]; then
+	docker pull "$ST_IMAGE"
+fi
+
 docker run -d --entrypoint="/bin/sh" --name st_container "$ST_IMAGE" > /dev/null 2>&1
 
 # shellcheck disable=SC2086

--- a/structure_tests/ext_run.sh
+++ b/structure_tests/ext_run.sh
@@ -72,6 +72,7 @@ if [ $VERBOSE -eq 1 ]; then
 	CMD_STRING=$CMD_STRING" -test.v"
 fi
 
+docker pull "$ST_IMAGE"
 docker run -d --entrypoint="/bin/sh" --name st_container "$ST_IMAGE" > /dev/null 2>&1
 
 # shellcheck disable=SC2086

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -15,10 +15,9 @@ import (
 )
 
 func TestAll(t *testing.T) {
-	var err error
-	var tests StructureTest
 	for _, file := range configFiles {
-		if tests, err = Parse(file); err != nil {
+		tests, err := Parse(file)
+		if err != nil {
 			log.Fatalf("Error parsing config file: %s", err)
 		}
 		log.Printf("Running tests for file %s", file)
@@ -67,8 +66,11 @@ func Parse(fp string) (StructureTest, error) {
 	if st == nil {
 		return nil, errors.New("Unsupported schema version: " + version)
 	}
-	unmarshal(testContents, st)
-	tests, ok := st.(StructureTest) //type assertion
+
+	testHolder := st.New()
+
+	unmarshal(testContents, testHolder)
+	tests, ok := testHolder.(StructureTest) //type assertion
 	if !ok {
 		return nil, errors.New("Error encountered when type casting Structure Test interface!")
 	}

--- a/structure_tests/types.go
+++ b/structure_tests/types.go
@@ -34,7 +34,7 @@ type VersionHolder interface {
 	New() StructureTest
 }
 
-type VersionHolderv1 struct {}
+type VersionHolderv1 struct{}
 
 func (v VersionHolderv1) New() StructureTest {
 	return new(StructureTestv1)

--- a/structure_tests/types.go
+++ b/structure_tests/types.go
@@ -20,8 +20,8 @@ func (a *arrayFlags) Set(value string) error {
 	return nil
 }
 
-var schemaVersions map[string]interface{} = map[string]interface{}{
-	"1.0.0": new(StructureTestv1),
+var schemaVersions map[string]VersionHolder = map[string]VersionHolder{
+	"1.0.0": new(VersionHolderv1),
 }
 
 type SchemaVersion struct {
@@ -29,3 +29,13 @@ type SchemaVersion struct {
 }
 
 type Unmarshaller func([]byte, interface{}) error
+
+type VersionHolder interface {
+	New() StructureTest
+}
+
+type VersionHolderv1 struct {}
+
+func (v VersionHolderv1) New() StructureTest {
+	return new(StructureTestv1)
+}


### PR DESCRIPTION
Previously, the "holder" struct contained within the schema map was being reused for multiple config file parse runs; this was causing values from previously parsed config files to stick around inside of test parameters during later test runs, with obviously wonky results. Now, keep a map containing an interface that provides a constructor method, so we can create a new object for each parsing run.

@dlorenc @sharifelgamal 