### PR TITLE
exit script if any component fails and fix entrypoint

### DIFF
--- a/structure_tests/ext_run.sh
+++ b/structure_tests/ext_run.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+set -e
+
 VERBOSE=0
 PULL=1
 CMD_STRING=""
-ENTRYPOINT="./test/structure_test"
+ENTRYPOINT="/test/structure_test"
 ST_IMAGE="gcr.io/gcp-runtimes/structure_test"
 CONFIG_COUNTER=0
 USAGE_STRING="Usage: $0 [-i <image>] [-c <config>] [-v] [-e <entrypoint>] [--no-pull]"


### PR DESCRIPTION
the original entrypoint was causing the script to fail if the container was started in any directory other than root.

@dlorenc