### PR TITLE
support setting environment variables and checking specific exit codes in command tests

### DIFF
--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -37,5 +37,26 @@ func validateCommandTestV1(t *testing.T, tt CommandTestv1) {
 	if tt.Command == nil || len(tt.Command) == 0 {
 		t.Fatalf("Please provide a valid command to run for test %s", tt.Name)
 	}
+	if tt.Setup != nil {
+		for _, c := range tt.Setup {
+			if len(c) == 0 {
+				t.Fatalf("Error in setup command configuration encountered; please check formatting and remove all empty setup commands.")
+			}
+		}
+	}
+	if tt.Teardown != nil {
+		for _, c := range tt.Teardown {
+			if len(c) == 0 {
+				t.Fatalf("Error in teardown command configuration encountered; please check formatting and remove all empty teardown commands.")
+			}
+		}
+	}
+	if tt.EnvVars != nil {
+		for _, c := range tt.EnvVars {
+			if len(c) == 0 {
+				t.Fatalf("Error in env var configuration encountered; please check formatting and remove all empty env var commands.")
+			}
+		}
+	}
 	t.Logf("COMMAND TEST: %s", tt.Name)
 }

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -20,9 +20,9 @@ import (
 
 type CommandTestv1 struct {
 	Name           string
-	Setup          [][]string
-	Teardown       [][]string
-	EnvVars        [][]string
+	Setup          []Command
+	Teardown       []Command
+	EnvVars        []EnvVar
 	ExitCode       int
 	Command        []string
 	ExpectedOutput []string
@@ -53,9 +53,9 @@ func validateCommandTestV1(t *testing.T, tt CommandTestv1) {
 		}
 	}
 	if tt.EnvVars != nil {
-		for _, c := range tt.EnvVars {
-			if len(c) == 0 {
-				t.Fatalf("Error in env var configuration encountered; please check formatting and remove all empty env var commands.")
+		for _, env_var := range tt.EnvVars {
+			if env_var.Key == "" || env_var.Value == "" {
+				t.Fatalf("Please provide non-empty keys and values for all specified env_vars")
 			}
 		}
 	}

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -23,6 +23,7 @@ type CommandTestv1 struct {
 	Setup          [][]string
 	Teardown       [][]string
 	EnvVars        [][]string
+	ExitCode       int
 	Command        []string
 	ExpectedOutput []string
 	ExcludedOutput []string

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -22,6 +22,7 @@ type CommandTestv1 struct {
 	Name           string
 	Setup          [][]string
 	Teardown       [][]string
+	EnvVars        [][]string
 	Command        []string
 	ExpectedOutput []string
 	ExcludedOutput []string

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -38,7 +38,7 @@ func (st StructureTestv1) RunAll(t *testing.T) {
 func (st StructureTestv1) RunCommandTests(t *testing.T) {
 	for _, tt := range st.CommandTests {
 		validateCommandTestV1(t, tt)
-		SetEnvVars(tt.EnvVars)
+		SetEnvVars(t, tt.EnvVars)
 		for _, setup := range tt.Setup {
 			ProcessCommand(t, setup, false)
 		}
@@ -145,7 +145,9 @@ func SetEnvVars(t *testing.T, vars [][]string) {
 		if len(pair) != 2 {
 			t.Fatalf("Invalid environment variable pair: %v", pair)
 		}
-		os.Setenv(pair[0], pair[1])
+		if err := os.Setenv(pair[0], os.ExpandEnv(pair[1])); err != nil {
+			t.Fatalf("error setting env var: %s", err)
+		}
 	}
 }
 

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -101,6 +101,10 @@ func (st StructureTestv1) RunFileContentTests(t *testing.T) {
 
 func ProcessCommand(t *testing.T, fullCommand []string, checkOutput bool) (string, string) {
 	var cmd *exec.Cmd
+	if len(fullCommand) == 0 {
+		t.Logf("empty command provided: skipping...")
+		return "", ""
+	}
 	command := fullCommand[0]
 	flags := fullCommand[1:]
 	if len(flags) > 0 {

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -149,12 +149,9 @@ func ProcessCommand(t *testing.T, fullCommand []string, checkOutput bool) (strin
 	return stdout, stderr, exitCode
 }
 
-func SetEnvVars(t *testing.T, vars [][]string) {
-	for _, pair := range vars {
-		if len(pair) != 2 {
-			t.Fatalf("Invalid environment variable pair: %v", pair)
-		}
-		if err := os.Setenv(pair[0], os.ExpandEnv(pair[1])); err != nil {
+func SetEnvVars(t *testing.T, vars []EnvVar) {
+	for _, env_var := range vars {
+		if err := os.Setenv(env_var.Key, os.ExpandEnv(env_var.Value)); err != nil {
 			t.Fatalf("error setting env var: %s", err)
 		}
 	}

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -115,6 +115,7 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string, checkO
 	command := fullCommand[0]
 	flags := fullCommand[1:]
 	originalVars := SetEnvVars(t, envVars)
+	defer ResetEnvVars(t, originalVars)
 	if len(flags) > 0 {
 		cmd = exec.Command(command, flags...)
 	} else {
@@ -153,7 +154,6 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string, checkO
 	} else {
 		exitCode = cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 	}
-	ResetEnvVars(t, originalVars)
 	return stdout, stderr, exitCode
 }
 

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"testing"
 )
@@ -37,6 +38,7 @@ func (st StructureTestv1) RunAll(t *testing.T) {
 func (st StructureTestv1) RunCommandTests(t *testing.T) {
 	for _, tt := range st.CommandTests {
 		validateCommandTestV1(t, tt)
+		SetEnvVars(tt.EnvVars)
 		for _, setup := range tt.Setup {
 			ProcessCommand(t, setup, false)
 		}
@@ -136,6 +138,15 @@ func ProcessCommand(t *testing.T, fullCommand []string, checkOutput bool) (strin
 		}
 	}
 	return stdout, stderr
+}
+
+func SetEnvVars(t *testing.T, vars [][]string) {
+	for _, pair := range vars {
+		if len(pair) != 2 {
+			t.Fatalf("Invalid environment variable pair: %v", pair)
+		}
+		os.Setenv(pair[0], pair[1])
+	}
 }
 
 func CheckOutput(t *testing.T, tt CommandTestv1, stdout string, stderr string) {

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -153,7 +153,7 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string, checkO
 	return stdout, stderr, exitCode
 }
 
-func SetEnvVars(t *testing.T, vars []EnvVar) ([]EnvVar) {
+func SetEnvVars(t *testing.T, vars []EnvVar) []EnvVar {
 	var originalVars []EnvVar
 	for _, env_var := range vars {
 		originalVars = append(originalVars, EnvVar{env_var.Key, os.Getenv(env_var.Key)})

--- a/structure_tests/types.go
+++ b/structure_tests/types.go
@@ -55,8 +55,8 @@ func (v VersionHolderv1) New() StructureTest {
 }
 
 type EnvVar struct {
-	Key    string
-	Value  string
+	Key   string
+	Value string
 }
 
 type Command []string

--- a/structure_tests/types.go
+++ b/structure_tests/types.go
@@ -53,3 +53,10 @@ type VersionHolderv1 struct{}
 func (v VersionHolderv1) New() StructureTest {
 	return new(StructureTestv1)
 }
+
+type EnvVar struct {
+	Key    string
+	Value  string
+}
+
+type Command []string


### PR DESCRIPTION
this will add support for setting a list of environment variables inside the image under test. multiple tests have been doing this through creating a new "test image" that inherits from the actual image under test, and running the `ENV` command in the Dockerfile.

additionally, this adds support for specifying a specific expected exit code in a command test. if none is specified, this will default to 0; this will require that test writers are slightly more intentional with their test writing (which I would argue is a good thing).

finally, adds validation for the setup/teardown/envvar fields in the command test struct (without it, a malformed test could cause the framework to panic).

@dlorenc 