### PR TITLE
fix tag check entrypoint

### DIFF
--- a/check_if_image_tag_exists/Dockerfile
+++ b/check_if_image_tag_exists/Dockerfile
@@ -15,6 +15,7 @@
 FROM gcr.io/cloud-builders/gcloud
 
 COPY main.py /
+RUN ln -s /usr/local/bin/python /usr/bin/python
 
 # Since we're inheriting from the gcloud container, overwrite the entrypoint so we don't start in a gcloud command.
-ENTRYPOINT []
+ENTRYPOINT ["/main.py"]

--- a/check_if_image_tag_exists/README.md
+++ b/check_if_image_tag_exists/README.md
@@ -11,6 +11,4 @@ prevent users from unintentionally overwriting a tag in a remote repository.
 ```
    - name: gcr.io/gcp-runtimes/check_if_tag_exists:latest
      args:
-       - 'python'
-       - '/main.py'
        - '--image=<target_image_path>'```

--- a/check_if_image_tag_exists/main.py
+++ b/check_if_image_tag_exists/main.py
@@ -66,8 +66,8 @@ def main():
     args = parser.parse_args()
 
     if args.image is None:
-        sys.exit('Please provide fully qualified remote path for the ' \
-              'target image.')
+        sys.exit('Please provide fully qualified remote path for the '
+                 'target image.')
 
     check_if_tag_exists(args.image, args.force)
 

--- a/check_if_image_tag_exists/main.py
+++ b/check_if_image_tag_exists/main.py
@@ -28,8 +28,7 @@ def check_if_tag_exists(raw_image_path, force_build):
     else:
         image_tag = 'latest'
 
-    p = subprocess.Popen(["/builder/google-cloud-sdk/bin/gcloud "
-                          + "alpha container images list-tags "
+    p = subprocess.Popen(["gcloud alpha container images list-tags "
                           + "--format='value(tags)' --no-show-occurrences {0}"
                           .format(image_path)],
                          shell=True, stdout=subprocess.PIPE,
@@ -37,11 +36,11 @@ def check_if_tag_exists(raw_image_path, force_build):
 
     output, error = p.communicate()
     if p.returncode != 0:
-        sys.exit("Error encountered when retrieving existing image tags! "
-                 + "Full log: \n\n" + output)
+        sys.exit('Error encountered when retrieving existing image tags! '
+                 + 'Full log: \n\n' + output)
 
     existing_tags = set(tag.rstrip() for tag in output.split('\n'))
-    print "Existing tags for image {0}:".format(image_path)
+    print 'Existing tags for image {0}:'.format(image_path)
     for tag in existing_tags:
         print tag
 
@@ -49,7 +48,7 @@ def check_if_tag_exists(raw_image_path, force_build):
         print "Tag '{0}' already exists in remote repository!" \
               .format(image_tag)
         if not force_build:
-            sys.exit("Exiting build.")
+            sys.exit('Exiting build.')
         else:
             print "Forcing build. Tag '{0}' " \
                   "will be overwritten!".format(image_tag)
@@ -65,6 +64,10 @@ def main():
                         + 'target image')
     parser .add_argument('--force', action='store_true', default=False)
     args = parser.parse_args()
+
+    if args.image is None:
+        sys.exit('Please provide fully qualified remote path for the ' \
+              'target image.')
 
     check_if_tag_exists(args.image, args.force)
 

--- a/structure_tests/cloudbuild.yaml.in
+++ b/structure_tests/cloudbuild.yaml.in
@@ -4,5 +4,7 @@ steps:
           env: ['PROJECT_ROOT=github.com/GoogleCloudPlatform/runtimes-common']
         - name: gcr.io/cloud-builders/docker
           args: ['build', '-t', '${IMAGE}', './structure_tests']
+        - name: gcr.io/gcp-runtimes/check_if_tag_exists
+          args: ['--image=${IMAGE}']
 images:
         - '${IMAGE}'


### PR DESCRIPTION
I realized after doing this that with the addition of the tag reconciler we barely need this tool anymore....but it looked ugly to me so I fixed it. Now instead of passing `python /main.py --image={IMAGE}` you just pass the image name.

@dlorenc @sharifelgamal 