### PR TITLE
create logging wrapper to override testing.Log and allow custom formatting

### DIFF
--- a/check_if_image_tag_exists/cloudbuild.yaml.in
+++ b/check_if_image_tag_exists/cloudbuild.yaml.in
@@ -1,8 +1,11 @@
+
 steps:
   - name: gcr.io/cloud-builders/docker:latest
     args: ['build', '--tag=${IMAGE}', '.']
     id: BUILD
   - name: gcr.io/gcp-runtimes/structure_test:latest
-    args: ['--image', '${IMAGE}', '-v', '--config', '/workspace/test_config.json']
+    args: ['--image', '${IMAGE}', '-v',
+           '--config', '/workspace/structure_test.yaml',
+           '--config', '/workspace/structure_test_2.yaml']
     id: STRUCTURE_TEST
 images: ['${IMAGE}']

--- a/check_if_image_tag_exists/structure_test.yaml
+++ b/check_if_image_tag_exists/structure_test.yaml
@@ -6,21 +6,11 @@ commandTests:
   expectedError: ['']
   expectedOutput: ['Linux\n']
 
-- name: 'broken uname'
-  command: ['uname', '-s', '-asdf']
-  exitCode: 1
-  expectedError: ['.*[invalid | unrecognized].*']
-
 fileExistenceTests:
 - name: 'Root'
   path: '/'
   isDirectory: true
   shouldExist: true
-
-- name: 'Fake file'
-  path: '/foo/bar'
-  isDirectory: false
-  shouldExist: false  
 
 fileContentTests:  
 - name: 'main.py'

--- a/check_if_image_tag_exists/structure_test_2.yaml
+++ b/check_if_image_tag_exists/structure_test_2.yaml
@@ -1,0 +1,13 @@
+schemaVersion: "1.0.0"
+
+commandTests:
+- name: 'broken uname'
+  command: ['uname', '-s', '-asdf']
+  exitCode: 1
+  expectedError: ['.*[invalid | unrecognized].*']
+
+fileExistenceTests:
+- name: 'Fake file'
+  path: '/foo/bar'
+  isDirectory: false
+  shouldExist: false  

--- a/structure_tests/cloudbuild.yaml.in
+++ b/structure_tests/cloudbuild.yaml.in
@@ -5,6 +5,6 @@ steps:
         - name: gcr.io/cloud-builders/docker:latest
           args: ['build', '-t', '${IMAGE}', './structure_tests']
         - name: gcr.io/gcp-runtimes/check_if_tag_exists:latest
-          args: ['--image=${IMAGE}', '--force']
+          args: ['--image=${IMAGE}']
 images:
         - '${IMAGE}'

--- a/structure_tests/cloudbuild.yaml.in
+++ b/structure_tests/cloudbuild.yaml.in
@@ -5,6 +5,6 @@ steps:
         - name: gcr.io/cloud-builders/docker:latest
           args: ['build', '-t', '${IMAGE}', './structure_tests']
         - name: gcr.io/gcp-runtimes/check_if_tag_exists:latest
-          args: ['--image=${IMAGE}']
+          args: ['--image=${IMAGE}', '--force']
 images:
         - '${IMAGE}'

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -63,5 +62,6 @@ func validateCommandTestV1(t *testing.T, tt CommandTestv1) {
 }
 
 func (ct CommandTestv1) LogName() string {
-	return _Header("COMMAND TEST: %s", ct.Name)
+	_Header("COMMAND TEST: %s", ct.Name)
+	return ct.Name
 }

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -34,34 +34,34 @@ type CommandTestv1 struct {
 
 func validateCommandTestV1(t *testing.T, tt CommandTestv1) {
 	if tt.Name == "" {
-		t.Fatalf("Please provide a valid name for every test!")
+		_Fatal(t, "Please provide a valid name for every test!")
 	}
 	if tt.Command == nil || len(tt.Command) == 0 {
-		t.Fatalf("Please provide a valid command to run for test %s", tt.Name)
+		_Fatal(t, "Please provide a valid command to run for test %s", tt.Name)
 	}
 	if tt.Setup != nil {
 		for _, c := range tt.Setup {
 			if len(c) == 0 {
-				t.Fatalf("Error in setup command configuration encountered; please check formatting and remove all empty setup commands.")
+				_Fatal(t, "Error in setup command configuration encountered; please check formatting and remove all empty setup commands.")
 			}
 		}
 	}
 	if tt.Teardown != nil {
 		for _, c := range tt.Teardown {
 			if len(c) == 0 {
-				t.Fatalf("Error in teardown command configuration encountered; please check formatting and remove all empty teardown commands.")
+				_Fatal(t, "Error in teardown command configuration encountered; please check formatting and remove all empty teardown commands.")
 			}
 		}
 	}
 	if tt.EnvVars != nil {
 		for _, env_var := range tt.EnvVars {
 			if env_var.Key == "" || env_var.Value == "" {
-				t.Fatalf("Please provide non-empty keys and values for all specified env_vars")
+				_Fatal(t, "Please provide non-empty keys and values for all specified env_vars")
 			}
 		}
 	}
 }
 
 func (ct CommandTestv1) LogName() string {
-	return fmt.Sprintf("Command Test: %s", ct.Name)
+	return _Header("COMMAND TEST: %s", ct.Name)
 }

--- a/structure_tests/file_content_test_v1.go
+++ b/structure_tests/file_content_test_v1.go
@@ -28,13 +28,13 @@ type FileContentTestv1 struct {
 
 func validateFileContentTestV1(t *testing.T, tt FileContentTestv1) {
 	if tt.Name == "" {
-		t.Fatalf("Please provide a valid name for every test!")
+		_Fatal(t, "Please provide a valid name for every test!")
 	}
 	if tt.Path == "" {
-		t.Fatalf("Please provide a valid file path for test %s", tt.Name)
+		_Fatal(t, "Please provide a valid file path for test %s", tt.Name)
 	}
 }
 
 func (ft FileContentTestv1) LogName() string {
-	return fmt.Sprintf("File Content Test: %s", ft.Name)
+	return _Header("FILE CONTENT TEST: %s", ft.Name)
 }

--- a/structure_tests/file_content_test_v1.go
+++ b/structure_tests/file_content_test_v1.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -36,5 +35,6 @@ func validateFileContentTestV1(t *testing.T, tt FileContentTestv1) {
 }
 
 func (ft FileContentTestv1) LogName() string {
-	return _Header("FILE CONTENT TEST: %s", ft.Name)
+	_Header("FILE CONTENT TEST: %s", ft.Name)
+	return ft.Name
 }

--- a/structure_tests/file_existence_test_v1.go
+++ b/structure_tests/file_existence_test_v1.go
@@ -29,13 +29,13 @@ type FileExistenceTestv1 struct {
 
 func validateFileExistenceTestV1(t *testing.T, tt FileExistenceTestv1) {
 	if tt.Name == "" {
-		t.Fatalf("Please provide a valid name for every test!")
+		_Fatal(t, "Please provide a valid name for every test!")
 	}
 	if tt.Path == "" {
-		t.Fatalf("Please provide a valid file path for test %s", tt.Name)
+		_Fatal(t, "Please provide a valid file path for test %s", tt.Name)
 	}
 }
 
 func (ft FileExistenceTestv1) LogName() string {
-	return fmt.Sprintf("File Existence Test: %s", ft.Name)
+	return _Header("FILE EXISTENCE TEST: %s", ft.Name)
 }

--- a/structure_tests/file_existence_test_v1.go
+++ b/structure_tests/file_existence_test_v1.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -37,5 +36,6 @@ func validateFileExistenceTestV1(t *testing.T, tt FileExistenceTestv1) {
 }
 
 func (ft FileExistenceTestv1) LogName() string {
-	return _Header("FILE EXISTENCE TEST: %s", ft.Name)
+	_Header("FILE EXISTENCE TEST: %s", ft.Name)
+	return ft.Name
 }

--- a/structure_tests/licenses_test.go
+++ b/structure_tests/licenses_test.go
@@ -29,13 +29,13 @@ func checkFile(t *testing.T, licenseFile string) {
 	// Read through the copyright file and make sure don't have an unauthorized license
 	license, err := ioutil.ReadFile(licenseFile)
 	if err != nil {
-		t.Errorf("Error reading license file for %s: %s", licenseFile, err.Error())
+		_Error(t, "Error reading license file for %s: %s", licenseFile, err.Error())
 		return
 	}
 	contents := strings.ToUpper(string(license))
 	for _, b := range blacklist {
 		if strings.Contains(contents, b) {
-			t.Errorf("Invalid license for %s, license contains %s", licenseFile, b)
+			_Error(t, "Invalid license for %s, license contains %s", licenseFile, b)
 			return
 		}
 	}
@@ -46,14 +46,14 @@ func checkLicenses(t *testing.T, tt LicenseTestv1) {
 		root := "/usr/share/doc"
 		packages, err := ioutil.ReadDir(root)
 		if err != nil {
-			t.Fatalf("%s", err)
+			_Fatal(t, "%s", err)
 		}
 		for _, p := range packages {
 			if !p.IsDir() {
 				continue
 			}
 
-			t.Logf(p.Name())
+			_Info("License Test: %s", p.Name())
 
 			// Skip over packages in the whitelist
 			whitelisted := false
@@ -71,7 +71,7 @@ func checkLicenses(t *testing.T, tt LicenseTestv1) {
 			licenseFile := path.Join(root, p.Name(), "copyright")
 			_, err := os.Stat(licenseFile)
 			if err != nil {
-				t.Errorf("Error reading license file for %s: %s", p.Name(), err.Error())
+				_Error(t, "Error reading license file for %s: %s", p.Name(), err.Error())
 				continue
 			}
 

--- a/structure_tests/log_wrapper.go
+++ b/structure_tests/log_wrapper.go
@@ -21,14 +21,25 @@ import (
 	"testing"
 )
 
-const RED = "\033[0;31m"
-const GREEN = "\033[0;32m"
-const YELLOW = "\033[1;33m"
-const CYAN = "\033[0;36m"
-const BLUE = "\033[0;34m"
-const PURPLE = "\033[0;35m"
-const NC = "\033[0m" // No Color
+const (
+	RED = "\033[0;31m"
+	GREEN = "\033[0;32m"
+	YELLOW = "\033[1;33m"
+	CYAN = "\033[0;36m"
+	BLUE = "\033[0;34m"
+	PURPLE = "\033[0;35m"
+	NC = "\033[0m" // No Color
 
+
+	LOG_TEMPLATE = "LOG: %s"
+	INFO_TEMPLATE = YELLOW + "INFO: %s" + NC
+	HEADER_TEMPLATE = GREEN + "%s" + NC
+	SPECIAL_TEMPLATE = BLUE + "%s" + NC
+	ERROR_TEMPLATE = "\n" + RED + "ERROR: %s" + NC + "\n"
+	FATAL_TEMPLATE = "\n" + PURPLE + "FATAL: %s" + NC + "\n"
+)
+
+// ANSI Color Escape Codes
 // Black        0;30     Dark Gray     1;30
 // Red          0;31     Light Red     1;31
 // Green        0;32     Light Green   1;32
@@ -37,14 +48,6 @@ const NC = "\033[0m" // No Color
 // Purple       0;35     Light Purple  1;35
 // Cyan         0;36     Light Cyan    1;36
 // Light Gray   0;37     White         1;37
-
-const LOG_TEMPLATE = "LOG: %s"
-const INFO_TEMPLATE = YELLOW + "INFO: %s" + NC
-const HEADER_TEMPLATE = GREEN + "%s" + NC
-const SPECIAL_TEMPLATE = BLUE + "%s" + NC
-const ERROR_TEMPLATE = "\n" + RED + "ERROR: %s" + NC + "\n"
-const FATAL_TEMPLATE = "\n" + PURPLE + "FATAL: %s" + NC + "\n"
-
 
 var Log = log.New(os.Stdout,
 		"",

--- a/structure_tests/log_wrapper.go
+++ b/structure_tests/log_wrapper.go
@@ -1,0 +1,86 @@
+// Copyright 2016 Google Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+)
+
+const RED = "\033[0;31m"
+const GREEN = "\033[0;32m"
+const YELLOW = "\033[1;33m"
+const CYAN = "\033[0;36m"
+const BLUE = "\033[0;34m"
+const PURPLE = "\033[0;35m"
+const NC = "\033[0m" // No Color
+
+// Black        0;30     Dark Gray     1;30
+// Red          0;31     Light Red     1;31
+// Green        0;32     Light Green   1;32
+// Brown/Orange 0;33     Yellow        1;33
+// Blue         0;34     Light Blue    1;34
+// Purple       0;35     Light Purple  1;35
+// Cyan         0;36     Light Cyan    1;36
+// Light Gray   0;37     White         1;37
+
+const LOG_TEMPLATE = "LOG: %s"
+const INFO_TEMPLATE = YELLOW + "INFO: %s" + NC
+const HEADER_TEMPLATE = GREEN + "%s" + NC
+const SPECIAL_TEMPLATE = BLUE + "%s" + NC
+const ERROR_TEMPLATE = "\n" + RED + "ERROR: %s" + NC + "\n"
+const FATAL_TEMPLATE = "\n" + PURPLE + "FATAL: %s" + NC + "\n"
+
+
+var Log = log.New(os.Stdout,
+		"",
+		log.Ldate|log.Ltime)
+
+var Info = log.New(os.Stdout,
+        "", 0)
+
+var Error = log.New(os.Stderr,
+		"",
+		log.Ldate|log.Ltime)
+
+
+func _Log(text string, args ...interface{}) {
+	Log.Println(fmt.Sprintf(text, args...))
+}
+
+func _Info(text string, args ...interface{}) {
+	Info.Println(fmt.Sprintf(INFO_TEMPLATE, fmt.Sprintf(text, args...)))
+}
+
+func _Special(text string, args ...interface{}) {
+	Info.Println(fmt.Sprintf(SPECIAL_TEMPLATE, fmt.Sprintf(text, args...)))
+}
+
+func _Header(text string, args ...interface{}) string {
+	// returns formatted string to be passed to t.Run()
+	return fmt.Sprintf(HEADER_TEMPLATE, fmt.Sprintf(text, args...))
+}
+
+func _Error(t *testing.T, text string, args ...interface{}) {
+	Error.Println(fmt.Sprintf(ERROR_TEMPLATE, fmt.Sprintf(text, args...)))
+    t.Fail()
+}
+
+func _Fatal(t *testing.T, text string, args ...interface{}) {
+	Error.Println(fmt.Sprintf(FATAL_TEMPLATE, fmt.Sprintf(text, args...)))
+    t.FailNow()
+}

--- a/structure_tests/log_wrapper.go
+++ b/structure_tests/log_wrapper.go
@@ -71,9 +71,8 @@ func _Special(text string, args ...interface{}) {
 	Info.Println(fmt.Sprintf(SPECIAL_TEMPLATE, fmt.Sprintf(text, args...)))
 }
 
-func _Header(text string, args ...interface{}) string {
-	// returns formatted string to be passed to t.Run()
-	return fmt.Sprintf(HEADER_TEMPLATE, fmt.Sprintf(text, args...))
+func _Header(text string, args ...interface{}) {
+	Info.Println(fmt.Sprintf(HEADER_TEMPLATE, fmt.Sprintf(text, args...)))
 }
 
 func _Error(t *testing.T, text string, args ...interface{}) {

--- a/structure_tests/log_wrapper.go
+++ b/structure_tests/log_wrapper.go
@@ -22,21 +22,20 @@ import (
 )
 
 const (
-	RED = "\033[0;31m"
-	GREEN = "\033[0;32m"
+	RED    = "\033[0;31m"
+	GREEN  = "\033[0;32m"
 	YELLOW = "\033[1;33m"
-	CYAN = "\033[0;36m"
-	BLUE = "\033[0;34m"
+	CYAN   = "\033[0;36m"
+	BLUE   = "\033[0;34m"
 	PURPLE = "\033[0;35m"
-	NC = "\033[0m" // No Color
+	NC     = "\033[0m" // No Color
 
-
-	LOG_TEMPLATE = "LOG: %s"
-	INFO_TEMPLATE = YELLOW + "INFO: %s" + NC
-	HEADER_TEMPLATE = GREEN + "%s" + NC
+	LOG_TEMPLATE     = "LOG: %s"
+	INFO_TEMPLATE    = YELLOW + "INFO: %s" + NC
+	HEADER_TEMPLATE  = GREEN + "%s" + NC
 	SPECIAL_TEMPLATE = BLUE + "%s" + NC
-	ERROR_TEMPLATE = "\n" + RED + "ERROR: %s" + NC + "\n"
-	FATAL_TEMPLATE = "\n" + PURPLE + "FATAL: %s" + NC + "\n"
+	ERROR_TEMPLATE   = "\n" + RED + "ERROR: %s" + NC + "\n"
+	FATAL_TEMPLATE   = "\n" + PURPLE + "FATAL: %s" + NC + "\n"
 )
 
 // ANSI Color Escape Codes
@@ -50,16 +49,15 @@ const (
 // Light Gray   0;37     White         1;37
 
 var Log = log.New(os.Stdout,
-		"",
-		log.Ldate|log.Ltime)
+	"",
+	log.Ldate|log.Ltime)
 
 var Info = log.New(os.Stdout,
-        "", 0)
+	"", 0)
 
 var Error = log.New(os.Stderr,
-		"",
-		log.Ldate|log.Ltime)
-
+	"",
+	log.Ldate|log.Ltime)
 
 func _Log(text string, args ...interface{}) {
 	Log.Println(fmt.Sprintf(text, args...))
@@ -80,10 +78,10 @@ func _Header(text string, args ...interface{}) string {
 
 func _Error(t *testing.T, text string, args ...interface{}) {
 	Error.Println(fmt.Sprintf(ERROR_TEMPLATE, fmt.Sprintf(text, args...)))
-    t.Fail()
+	t.Fail()
 }
 
 func _Fatal(t *testing.T, text string, args ...interface{}) {
 	Error.Println(fmt.Sprintf(FATAL_TEMPLATE, fmt.Sprintf(text, args...)))
-    t.FailNow()
+	t.FailNow()
 }

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"flag"
 	"io/ioutil"
-	"log"
 	"os"
 	"regexp"
 	"strings"
@@ -34,26 +33,31 @@ func TestAll(t *testing.T) {
 	for _, file := range configFiles {
 		tests, err := Parse(file)
 		if err != nil {
-			log.Fatalf("Error parsing config file: %s", err)
+			_Fatal(t, "Error parsing config file: %s", err)
 		}
-		log.Printf("Running tests for file %s", file)
-		totalTests += tests.RunAll(t)
+		_Special("Running tests for file %s", file)
+
+		numTests := tests.RunAll(t)
+		_Special("Total tests run from file %s: %d", file, numTests)
+		_Log("\n")
+		totalTests += numTests
 	}
 	if totalTests == 0 {
-		t.Fatalf("No tests run! Check config file format.")
+		_Fatal(t, "No tests run! Check config file format.")
 	} else {
-		t.Logf("Total tests run: %d", totalTests)
+		_Special("Total tests run: %d", totalTests)
 	}
 }
 
 func compileAndRunRegex(regex string, base string, t *testing.T, err string, shouldMatch bool) {
 	r, rErr := regexp.Compile(regex)
 	if rErr != nil {
-		t.Errorf("Error compiling regex %s : %s", regex, rErr.Error())
+		// t.Errorf("Error compiling regex %s : %s", regex, rErr.Error())
+		_Error(t, "Error compiling regex %s : %s", regex, rErr.Error())
 		return
 	}
 	if shouldMatch != r.MatchString(base) {
-		t.Errorf(err)
+		_Error(t, err)
 	}
 }
 

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -78,21 +78,21 @@ func (st StructureTestv1) RunFileExistenceTests(t *testing.T) int {
 			}
 			if tt.ShouldExist && err != nil {
 				if tt.IsDirectory {
-					t.Errorf("Directory %s should exist but does not!", tt.Path)
+					_Error("Directory %s should exist but does not!", tt.Path)
 				} else {
-					t.Errorf("File %s should exist but does not!", tt.Path)
+					_Error("File %s should exist but does not!", tt.Path)
 				}
 			} else if !tt.ShouldExist && err == nil {
 				if tt.IsDirectory {
-					t.Errorf("Directory %s should not exist but does!", tt.Path)
+					_Error("Directory %s should not exist but does!", tt.Path)
 				} else {
-					t.Errorf("File %s should not exist but does!", tt.Path)
+					_Error("File %s should not exist but does!", tt.Path)
 				}
 			}
 			if tt.Permissions != "" {
 				perms := info.Mode()
 				if perms.String() != tt.Permissions {
-					t.Errorf("%s has incorrect permissions. Expected: %s, Actual: %s", tt.Path, tt.Permissions, perms.String())
+					_Error("%s has incorrect permissions. Expected: %s, Actual: %s", tt.Path, tt.Permissions, perms.String())
 				}
 			}
 			counter++
@@ -108,7 +108,7 @@ func (st StructureTestv1) RunFileContentTests(t *testing.T) int {
 			validateFileContentTestV1(t, tt)
 			actualContents, err := ioutil.ReadFile(tt.Path)
 			if err != nil {
-				t.Errorf("Failed to open %s. Error: %s", tt.Path, err)
+				_Error("Failed to open %s. Error: %s", tt.Path, err)
 			}
 
 			contents := string(actualContents[:])
@@ -145,7 +145,7 @@ func (st StructureTestv1) RunLicenseTests(t *testing.T) int {
 func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string, checkOutput bool) (string, string, int) {
 	var cmd *exec.Cmd
 	if len(fullCommand) == 0 {
-		t.Logf("empty command provided: skipping...")
+		_Info("empty command provided: skipping...")
 		return "", "", -1
 	}
 	command := fullCommand[0]
@@ -159,9 +159,9 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string, checkO
 	}
 
 	if checkOutput {
-		t.Logf("Executing: %s", cmd.Args)
+		_Info("Executing: %s", cmd.Args)
 	} else {
-		t.Logf("Executing setup/teardown: %s", cmd.Args)
+		_Info("Executing setup/teardown: %s", cmd.Args)
 	}
 
 	var outbuf, errbuf bytes.Buffer
@@ -172,19 +172,19 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string, checkO
 	err := cmd.Run()
 	stdout := outbuf.String()
 	if stdout != "" {
-		t.Logf("stdout: %s", stdout)
+		_Log("stdout: %s", stdout)
 	}
 	stderr := errbuf.String()
 	if stderr != "" {
-		t.Logf("stderr: %s", stderr)
+		_Log("stderr: %s", stderr)
 	}
 	var exitCode int
 	if err != nil {
 		if checkOutput {
 			// The test might be designed to run a command that exits with an error.
-			t.Logf("Error running command: %s. Continuing.", err)
+			_Info("Error running command: %s. Continuing.", err)
 		} else {
-			t.Fatalf("Error running setup/teardown command: %s.", err)
+			_Fatal(t, "Error running setup/teardown command: %s.", err)
 		}
 		exitCode = err.(*exec.ExitError).Sys().(syscall.WaitStatus).ExitStatus()
 	} else {
@@ -200,7 +200,7 @@ func SetEnvVars(t *testing.T, vars []EnvVar) []EnvVar {
 	for _, env_var := range vars {
 		originalVars = append(originalVars, EnvVar{env_var.Key, os.Getenv(env_var.Key)})
 		if err := os.Setenv(env_var.Key, os.ExpandEnv(env_var.Value)); err != nil {
-			t.Fatalf("error setting env var: %s", err)
+			_Fatal(t, "error setting env var: %s", err)
 		}
 	}
 	return originalVars
@@ -218,7 +218,7 @@ func ResetEnvVars(t *testing.T, vars []EnvVar) {
 			err = os.Setenv(env_var.Key, env_var.Value)
 		}
 		if err != nil {
-			t.Fatalf("error resetting env var: %s", err)
+			_Fatal(t, "error resetting env var: %s", err)
 		}
 	}
 }
@@ -241,6 +241,6 @@ func CheckOutput(t *testing.T, tt CommandTestv1, stdout string, stderr string, e
 		compileAndRunRegex(outStr, stdout, t, errMsg, false)
 	}
 	if tt.ExitCode != exitCode {
-		t.Errorf("Test %s exited with incorrect error code! Expected: %d, Actual: %d", tt.Name, tt.ExitCode, exitCode)
+		_Error(t, "Test %s exited with incorrect error code! Expected: %d, Actual: %d", tt.Name, tt.ExitCode, exitCode)
 	}
 }

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -78,21 +78,21 @@ func (st StructureTestv1) RunFileExistenceTests(t *testing.T) int {
 			}
 			if tt.ShouldExist && err != nil {
 				if tt.IsDirectory {
-					_Error("Directory %s should exist but does not!", tt.Path)
+					_Error(t, "Directory %s should exist but does not!", tt.Path)
 				} else {
-					_Error("File %s should exist but does not!", tt.Path)
+					_Error(t, "File %s should exist but does not!", tt.Path)
 				}
 			} else if !tt.ShouldExist && err == nil {
 				if tt.IsDirectory {
-					_Error("Directory %s should not exist but does!", tt.Path)
+					_Error(t, "Directory %s should not exist but does!", tt.Path)
 				} else {
-					_Error("File %s should not exist but does!", tt.Path)
+					_Error(t, "File %s should not exist but does!", tt.Path)
 				}
 			}
 			if tt.Permissions != "" {
 				perms := info.Mode()
 				if perms.String() != tt.Permissions {
-					_Error("%s has incorrect permissions. Expected: %s, Actual: %s", tt.Path, tt.Permissions, perms.String())
+					_Error(t, "%s has incorrect permissions. Expected: %s, Actual: %s", tt.Path, tt.Permissions, perms.String())
 				}
 			}
 			counter++
@@ -108,7 +108,7 @@ func (st StructureTestv1) RunFileContentTests(t *testing.T) int {
 			validateFileContentTestV1(t, tt)
 			actualContents, err := ioutil.ReadFile(tt.Path)
 			if err != nil {
-				_Error("Failed to open %s. Error: %s", tt.Path, err)
+				_Error(t, "Failed to open %s. Error: %s", tt.Path, err)
 			}
 
 			contents := string(actualContents[:])


### PR DESCRIPTION
**Update 1/3: Pulled subtest code out into a separate PR: https://github.com/GoogleCloudPlatform/runtimes-common/pull/83**

~~**Update 12/29: This now uses Golang 1.7's new ["subtest"](https://blog.golang.org/subtests) feature when running all tests, which by default will log the result of each individual test.**~~

This creates a wrapper around Golang's standard logging which gives a bit more flexibility in the formatting of the logs. By unifying the standard logging module with the testing.Log module, we can guarantee the logs are written sequentially so nothing appears "out of order" eliminating some confusion.

Also adds colorization to some of the different log levels for more clarity.

![selection_007](https://cloud.githubusercontent.com/assets/5531168/24121028/f4d89e8e-0d73-11e7-82b0-a783a55d1df6.png)

Fixes https://github.com/GoogleCloudPlatform/runtimes-common/issues/53

@dlorenc @duggelz @aslo