### PR TITLE
Remove python symlinking, since it's already done in gcloud base image

### DIFF
--- a/check_if_image_tag_exists/Dockerfile
+++ b/check_if_image_tag_exists/Dockerfile
@@ -15,7 +15,6 @@
 FROM gcr.io/cloud-builders/gcloud
 
 COPY main.py /
-RUN ln -s /usr/local/bin/python /usr/bin/python
 
 # Since we're inheriting from the gcloud container, overwrite the entrypoint so we don't start in a gcloud command.
 ENTRYPOINT ["/main.py"]


### PR DESCRIPTION
Instead of inheriting from a Python base image, the gcloud base image now inherits from Ubuntu and manually installs Python (for all users). This command fails because it doesn't need to be run.

@dlorenc 