### PR TITLE
add script to publish runtime-builders to GCS

### DIFF
--- a/runtime_builders/README.md
+++ b/runtime_builders/README.md
@@ -1,0 +1,14 @@
+Runtime Builder
+===============
+
+This script takes a cloudbuild YAML config file, with all of it's build step images templated with tag names, resolves each of those tag names to a specific SHA256 digest, and uploads that pinned config file to GCS. The main purpose of this is to ensure that when a runtime builder is written, it is pinned to specific versions of each of its build steps to make a perfectly reproducible build.
+
+Runtime maintainers will write their builds as a list of cloudbuild steps that the image will go through as it is being assembled and tested. Each of these steps is itself a Docker image, so in the cloudbuild config file the specific tag of the image to be used should be specified. In order to eliminate confusion, the tags must be templated in a specific format different from the way tags are normally specified, e.g.:
+
+				name: gcr.io/gcp-runtimes/structure_test:${latest}
+
+When this script is run, it will find and replace all templated tags in the config file with their corresponding digests. For example, the image specified above might be converted into something like:
+
+				name: gcr.io/gcp-runtimes/structure_test@sha256:a3e9e8b880c5ca4322f2ea5f7fb90c16841f3da9072cb497e136ba2f44601e29
+
+Once all of the tags in the file have been substituted out, the new file will be written to a bucket in Google Cloud Storage. This bucket will be accessible to builders and maintainers of the runtime images, and will be used anytime a new image needs to be built.

--- a/runtime_builders/publish_runtime.py
+++ b/runtime_builders/publish_runtime.py
@@ -18,12 +18,10 @@ import argparse
 from datetime import datetime
 import json
 import logging
-import os
 import regex
 from ruamel import yaml
 import subprocess
 import sys
-import tempfile
 
 from google.cloud import storage
 
@@ -97,7 +95,6 @@ def _resolve_tag(image):
             base_image = m.string[0:m.start()-1]
         else:
             logging.error('Error when parsing image tag!')
-            logging.error(e)
             sys.exit(1)
 
     command = ['gcloud', 'beta', 'container', 'images',

--- a/runtime_builders/publish_runtime.py
+++ b/runtime_builders/publish_runtime.py
@@ -64,19 +64,20 @@ def main():
     _publish_to_gcs(templated_file, args.language, args.bucket)
 
 
-'''
-Given a templated YAML cloudbuild config file, parse it, resolve image tags
-on each build step's image to the corresponding digest, and write new config
-with fully qualified images to temporary file for upload to GCS.
-
-Keyword arguments:
-config_file -- string representing path to templated cloudbuild YAML config file
-
-Return value:
-path to temporary file containing fully qualified config file, to be
-published to GCS.
-'''
 def _resolve_tags(config_file):
+    """
+    Given a templated YAML cloudbuild config file, parse it, resolve image tags
+    on each build step's image to the corresponding digest, and write new
+    config with fully qualified images to temporary file for upload to GCS.
+
+    Keyword arguments:
+    config_file -- string representing path to
+    templated cloudbuild YAML config file
+
+    Return value:
+    path to temporary file containing fully qualified config file, to be
+    published to GCS.
+    """
     with open(config_file, 'r') as infile:
         try:
             config = yaml.round_trip_load(infile)
@@ -101,11 +102,11 @@ def _resolve_tags(config_file):
             infile.close()
 
 
-'''
-Given a path to a tagged Docker image in GCR, replace the tag with its
-corresponding sha256 digest. 
-'''
 def _resolve_tag(image):
+    """
+    Given a path to a tagged Docker image in GCR, replace the tag with its
+    corresponding sha256 digest.
+    """
     if image is None:
         raise Exception('Please provide image')
 
@@ -135,10 +136,10 @@ def _resolve_tag(image):
                   'image {1}'.format(target_tag, base_image))
 
 
-'''
-Given a cloudbuild YAML config file, publish the file to a bucket in GCS.
-'''
 def _publish_to_gcs(builder_file, language, bucket):
+    """
+    Given a cloudbuild YAML config file, publish the file to a bucket in GCS.
+    """
     client = storage.Client()
 
     runtime_bucket = client.get_bucket(bucket)

--- a/runtime_builders/publish_runtime.py
+++ b/runtime_builders/publish_runtime.py
@@ -26,8 +26,6 @@ import tempfile
 
 from google.cloud import storage
 
-# TAG_PATTERN = re.compile('.*/.*/.*:\$\{.*\}')
-
 LANGUAGES = [
     'java',
     'python',
@@ -35,8 +33,7 @@ LANGUAGES = [
     'nodejs',
     'golang',
     'dotnet',
-    'php',
-    'test'
+    'php'
 ]
 
 
@@ -81,28 +78,6 @@ published to GCS.
 '''
 def _resolve_tags(config_file):
     with open(config_file, 'r') as infile:
-
-        # try:
-        #   config = f.readlines()
-        #   with open('/tmp/test.txt', 'w') as outfile:
-        #     try:
-        #       for line in config:
-        #         # print line
-        #         # match = re.search(TAG_REGEX, line)
-        #         match = TAG_PATTERN.search(line)
-        #         if match is not None:
-        #           print 'match: {0}'.format(
-        #               match.string[match.start():match.end()])
-        #           # print match.span()
-        #         # if TAG_PATTERN.matches(line):
-        #           outfile.write(_resolve_tag_in_line(line))
-        #         else:
-        #           outfile.write(line)
-        #     finally:
-        #       outfile.close()
-        # finally:
-        #   f.close()
-
         try:
             config = yaml.round_trip_load(infile)
 
@@ -121,7 +96,7 @@ def _resolve_tags(config_file):
             return ofile
 
         except yaml.YAMLError as e:
-            print(e)
+            logging.error(e)
         finally:
             infile.close()
 

--- a/runtime_builders/publish_runtime.py
+++ b/runtime_builders/publish_runtime.py
@@ -18,14 +18,11 @@ import argparse
 from datetime import datetime
 import json
 import logging
-import regex
 from ruamel import yaml
 import subprocess
 import sys
 
 from google.cloud import storage
-
-TAG_REGEX = '(?<=:|@)(.*)'
 
 
 def main():
@@ -88,16 +85,12 @@ def _resolve_tag(image):
         logging.error('Image \'{0}\' must contain explicit tag or '
                       'digest!'.format(image))
         sys.exit(1)
-    elif 'sha256' in image:
+    elif '@sha256' in image:
         return image
     else:
-        m = regex.search(TAG_REGEX, image)
-        if m:
-            target_tag = m.string[m.start():m.end()]
-            base_image = m.string[0:m.start()-1]
-        else:
-            logging.error('Error when parsing image tag!')
-            sys.exit(1)
+        parts = image.split(':')
+        base_image = parts[0]
+        target_tag = parts[1]
 
     command = ['gcloud', 'beta', 'container', 'images',
                'list-tags', base_image, '--format=json']

--- a/runtime_builders/publish_runtime.py
+++ b/runtime_builders/publish_runtime.py
@@ -1,0 +1,185 @@
+#!/usr/bin/python
+
+# Copyright 2016 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from datetime import datetime
+import json
+import logging
+import os
+from ruamel import yaml
+import subprocess
+import sys
+import tempfile
+
+from google.cloud import storage
+
+# TAG_PATTERN = re.compile('.*/.*/.*:\$\{.*\}')
+
+LANGUAGES = [
+    'java',
+    'python',
+    'ruby',
+    'nodejs',
+    'golang',
+    'dotnet',
+    'php',
+    'test'
+]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--infile', '-i', help='file(s) to read')
+    parser.add_argument('--bucket', '-b',
+                        help='GCS bucket to publish runtime to',
+                        default='runtime-builders')
+    parser.add_argument('--language', '-l',
+                        help='the language associated with this builder')
+    args = parser.parse_args()
+
+    if args.infile is None:
+        logging.error('Please specify templated input YAML file.')
+        return 1
+    if args.language is None:
+        logging.error('Please specify language to '
+                      'associate this builder with.')
+        return 1
+    if args.language not in LANGUAGES:
+        logging.error('Invalid language \'{0}\' specified! '
+                      'Options:'.format(args.language))
+        logging.error(LANGUAGES)
+        return 1
+
+    templated_file = _resolve_tags(args.infile)
+    _publish_to_gcs(templated_file, args.language, args.bucket)
+
+
+'''
+Given a templated YAML cloudbuild config file, parse it, resolve image tags
+on each build step's image to the corresponding digest, and write new config
+with fully qualified images to temporary file for upload to GCS.
+
+Keyword arguments:
+config_file -- string representing path to templated cloudbuild YAML config file
+
+Return value:
+path to temporary file containing fully qualified config file, to be
+published to GCS.
+'''
+def _resolve_tags(config_file):
+    with open(config_file, 'r') as infile:
+
+        # try:
+        #   config = f.readlines()
+        #   with open('/tmp/test.txt', 'w') as outfile:
+        #     try:
+        #       for line in config:
+        #         # print line
+        #         # match = re.search(TAG_REGEX, line)
+        #         match = TAG_PATTERN.search(line)
+        #         if match is not None:
+        #           print 'match: {0}'.format(
+        #               match.string[match.start():match.end()])
+        #           # print match.span()
+        #         # if TAG_PATTERN.matches(line):
+        #           outfile.write(_resolve_tag_in_line(line))
+        #         else:
+        #           outfile.write(line)
+        #     finally:
+        #       outfile.close()
+        # finally:
+        #   f.close()
+
+        try:
+            config = yaml.round_trip_load(infile)
+
+            for step in config.get('steps'):
+                image = step.get('name')
+                templated_step = _resolve_tag(image)
+                step['name'] = templated_step
+
+            s = yaml.round_trip_dump(config)
+
+            fd, ofile = tempfile.mkstemp()
+            with open(ofile, 'w') as outfile:
+                outfile.write(s)
+            outfile.close()
+            os.close(fd)
+            return ofile
+
+        except yaml.YAMLError as e:
+            print(e)
+        finally:
+            infile.close()
+
+
+'''
+Given a path to a tagged Docker image in GCR, replace the tag with its
+corresponding sha256 digest. 
+'''
+def _resolve_tag(image):
+    if image is None:
+        raise Exception('Please provide image')
+
+    if ':' not in image:
+        logging.info('Image does not contain tag: defaulting to "latest"')
+        base_image = image
+        target_tag = 'latest'
+    else:
+        base_image = image.split(':')[0]
+        target_tag = image.split(':')[1].strip('${}')
+
+    command = ['gcloud', 'beta', 'container', 'images',
+               'list-tags', base_image, '--format=json']
+
+    try:
+        output = subprocess.check_output(command)
+        entries = json.loads(output)
+        for image in entries:
+            for tag in image.get('tags'):
+                if tag == target_tag:
+                    digest = image.get('digest')
+                    return base_image + '@' + digest
+    except subprocess.CalledProcessError as e:
+        logging.error(e)
+
+    logging.error('No digest found for tag {0} on '
+                  'image {1}'.format(target_tag, base_image))
+
+
+'''
+Given a cloudbuild YAML config file, publish the file to a bucket in GCS.
+'''
+def _publish_to_gcs(builder_file, language, bucket):
+    client = storage.Client()
+
+    runtime_bucket = client.get_bucket(bucket)
+
+    if runtime_bucket is None:
+        logging.error('Bucket {0} not found!'.format(bucket))
+
+    builder_name = '{0}-runtime-{1}.yaml'.format(
+        language,
+        datetime.now().strftime('%Y%m%d%H%M%S'))
+
+    blob = storage.Blob(builder_name, runtime_bucket)
+
+    with open(builder_file, 'r') as f:
+        blob.upload_from_file(f)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/runtime_builders/publish_runtime.py
+++ b/runtime_builders/publish_runtime.py
@@ -37,7 +37,7 @@ LANGUAGES = [
     'php'
 ]
 
-TAG_REGEX = '(?<=gcr\.io/.*/.*):\${.*}'
+TAG_REGEX = '(?<=:|@)(.*)'
 
 
 def main():
@@ -105,17 +105,19 @@ def _resolve_tag(image):
     corresponding sha256 digest.
     """
     if ':' not in image:
-        logging.error('Image must contain explicit tag!')
+        logging.error('Image \'{0}\' must contain explicit tag or '
+                      'digest!'.format(image))
         sys.exit(1)
+    elif 'sha256' in image:
+        return image
     else:
         m = regex.search(TAG_REGEX, image)
         if m:
-            templated_tag = m.string[m.start():m.end()]
-            target_tag = templated_tag.strip(':${}')
-            base_image = m.string.replace(templated_tag, '')
+            target_tag = m.string[m.start():m.end()]
+            base_image = m.string[0:m.start()-1]
         else:
-            logging.error('Image must contain explicit tag, in the format:'
-                          '\'gcr.io/<project_id>/<image_name>:${<tag>}\'')
+            logging.error('Error when parsing image tag!')
+            logging.error(e)
             sys.exit(1)
 
     command = ['gcloud', 'beta', 'container', 'images',

--- a/runtime_builders/publish_runtime.py
+++ b/runtime_builders/publish_runtime.py
@@ -43,14 +43,15 @@ TAG_REGEX = '(?<=gcr\.io/.*/.*):\${.*}'
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--infile', '-i',
-                        help='file(s) to read',
+                        help='templated cloudbuild config file.',
                         required=True)
     parser.add_argument('--bucket', '-b',
                         help='GCS bucket to publish runtime to',
                         default='runtime-builders')
-    parser.add_argument('--language', '-l',
+    parser.add_argument('--language',
                         help='the language associated with this builder',
-                        required=True)
+                        required=True,
+                        choices=LANGUAGES)
     args = parser.parse_args()
 
     if args.language not in LANGUAGES:
@@ -91,14 +92,11 @@ def _resolve_tags(config_file):
             fd, ofile = tempfile.mkstemp()
             with open(ofile, 'w') as outfile:
                 outfile.write(s)
-            outfile.close()
             os.close(fd)
             return ofile
-
         except yaml.YAMLError as e:
             logging.error(e)
-        finally:
-            infile.close()
+            sys.exit(1)
 
 
 def _resolve_tag(image):


### PR DESCRIPTION
This will be the heart of a job that will monitor the configuration files for the runtime builders, resolve their tags into pinned SHA256 digests and publish them to GCS.

Tests to come.

@sharifelgamal @dlorenc @znewman01