### PR TITLE
move tag config files from .../config to .../tag_config

### DIFF
--- a/reconciletags/config_integrity_test.py
+++ b/reconciletags/config_integrity_test.py
@@ -46,7 +46,7 @@ class ReconcilePresubmitTest(unittest.TestCase):
                       'authenticated')
 
     def test_json_structure(self):
-        for f in glob.glob('../tag_config/*.json'):
+        for f in glob.glob('../config/tag/*.json'):
             logging.debug('Testing {0}'.format(f))
             with open(f) as tag_map:
                 data = json.load(tag_map)

--- a/reconciletags/config_integrity_test.py
+++ b/reconciletags/config_integrity_test.py
@@ -46,7 +46,7 @@ class ReconcilePresubmitTest(unittest.TestCase):
                       'authenticated')
 
     def test_json_structure(self):
-        for f in glob.glob('../config/*.json'):
+        for f in glob.glob('../tag_config/*.json'):
             logging.debug('Testing {0}'.format(f))
             with open(f) as tag_map:
                 data = json.load(tag_map)

--- a/reconciletags/data_integrity_test.py
+++ b/reconciletags/data_integrity_test.py
@@ -23,7 +23,7 @@ class DataIntegrityTest(unittest.TestCase):
 
     def test_data_consistency(self):
         failed_digests = []
-        for f in glob.glob('../config/*.json'):
+        for f in glob.glob('../tag_config/*.json'):
             logging.debug('Testing {0}'.format(f))
             with open(f) as tag_map:
                 data = json.load(tag_map)

--- a/reconciletags/data_integrity_test.py
+++ b/reconciletags/data_integrity_test.py
@@ -23,7 +23,7 @@ class DataIntegrityTest(unittest.TestCase):
 
     def test_data_consistency(self):
         failed_digests = []
-        for f in glob.glob('../tag_config/*.json'):
+        for f in glob.glob('../config/tag/*.json'):
             logging.debug('Testing {0}'.format(f))
             with open(f) as tag_map:
                 data = json.load(tag_map)


### PR DESCRIPTION
there will be an accompanying change that actually moves these files. this is in preparation for another set of configs for the runtime builders (changing the name to avoid confusion)

@dlorenc @sharifelgamal 