### PR TITLE
consolidate config files into single directory

### DIFF
--- a/runtime_builders/template_builder.py
+++ b/runtime_builders/template_builder.py
@@ -50,7 +50,7 @@ def _resolve(directory, bucket):
                 project_name = project_cfg['project']
                 for builder in project_cfg['builders']:
                     cfg = os.path.abspath(str(builder['path']))
-                    name = builder.get('name', 'default')
+                    name = builder['name']
                     builder_name = project_name + '_' + name
 
                     templated_file = _resolve_tags(cfg)

--- a/runtime_builders/template_builder.py
+++ b/runtime_builders/template_builder.py
@@ -38,10 +38,10 @@ def main():
                         default='runtime-builders')
     args = parser.parse_args()
 
-    return _resolve(args.directory, args.bucket)
+    return _resolve_and_publish(args.directory, args.bucket)
 
 
-def _resolve(directory, bucket):
+def _resolve_and_publish(directory, bucket):
     try:
         gcs_paths = []
         for filepath in glob.glob(os.path.join(directory, '*.json')):


### PR DESCRIPTION
this allows us to keep all information related to a project's builder(s) in one location, and to keep all of the configs for each project in one location.

@dlorenc 