### PR TITLE
Making sure all deployed images are less than two weeks old.

### DIFF
--- a/reconciletags/latest_age_test.py
+++ b/reconciletags/latest_age_test.py
@@ -11,50 +11,54 @@ import os
 import subprocess
 import unittest
 
+
 class LatestAgeTest(unittest.TestCase):
 
-  def _get_latest_timestamp(self, repo):
-      images = json.loads(
-                subprocess.check_output(['gcloud', 'beta', 'container',
-                                         'images', 'list-tags',
-                                         '--no-show-occurrences',
-                                         '--format=json', repo]))
-      for image in images:
-          if 'latest' in image['tags']:
-              return datetime.datetime.strptime(
-                  image['timestamp']['datetime'], '%Y-%m-%d %H:%M:%S')
-      return None
+    def _get_latest_timestamp(self, repo):
+        images = json.loads(
+                  subprocess.check_output(['gcloud', 'beta', 'container',
+                                           'images', 'list-tags',
+                                           '--no-show-occurrences',
+                                           '--format=json', repo]))
+        for image in images:
+            if 'latest' in image['tags']:
+                return datetime.datetime.strptime(
+                    image['timestamp']['datetime'], '%Y-%m-%d %H:%M:%S')
+        return None
 
-  def test_latest_age(self):
-      old_repos = []
-      invalid_repos = []
-      for f in glob.glob('../config/tag/*.json'):
-          # We don't care about how old these images are
-          if f.endswith('runtimes_common.json'):
-              continue
-          logging.debug('Testing {0}'.format(f))
-          with open(f) as tag_map:
-              data = json.load(tag_map)
-              for project in data['projects']:
-                  full_repo = os.path.join(project['base_registry'],
-                                           project['repository'])
-                  last_deploy = self._get_latest_timestamp(full_repo)
-                  if last_deploy is None:
-                      invalid_repos.append(full_repo)
-                  threshold = last_deploy + datetime.timedelta(weeks=2)
-                  if threshold < datetime.datetime.now():
-                      old_repos.append(full_repo)
+    def test_latest_age(self):
+        old_repos = []
+        invalid_repos = []
+        for f in glob.glob('../config/tag/*.json'):
+            # We don't care about how old these images are
+            if f.endswith('runtimes_common.json'):
+                continue
+            logging.debug('Testing {0}'.format(f))
+            with open(f) as tag_map:
+                data = json.load(tag_map)
+                for project in data['projects']:
+                    full_repo = os.path.join(project['base_registry'],
+                                             project['repository'])
+                    last_deploy = self._get_latest_timestamp(full_repo)
+                    if last_deploy is None:
+                        invalid_repos.append(full_repo)
+                    threshold = last_deploy + datetime.timedelta(weeks=2)
+                    if threshold < datetime.datetime.now():
+                        old_repos.append(full_repo)
 
-      if len(old_repos) > 0 or len(invalid_repos) > 0:
-          msg = ''
-          if len(old_repos) > 0:
-              msg += 'The following repos have not been deployed in over two weeks: {0}. '.format(str(old_repos))
+        if len(old_repos) > 0 or len(invalid_repos) > 0:
+            msg = ''
+            if len(old_repos) > 0:
+                msg += ('The following repos have not been deployed in '
+                        'over two weeks: {0}. '.format(str(old_repos)))
 
-          if len(invalid_repos) > 0:
-              msg += 'The following repos have no latest tag: {0}.'.format(str(invalid_repos))
+            if len(invalid_repos) > 0:
+                msg += ('The following repos have no latest tag: {0}.'
+                        .format(str(invalid_repos)))
 
-          self.fail(msg)
+            self.fail(msg)
+
 
 if __name__ == '__main__':
-  logging.basicConfig(level=logging.DEBUG)
-  unittest.main()
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/reconciletags/latest_age_test.py
+++ b/reconciletags/latest_age_test.py
@@ -1,0 +1,60 @@
+"""Latest age tests.
+
+Checks the build date of the image marked as latest for a repository and fails
+if it's over two weeks old."""
+
+import datetime
+import glob
+import json
+import logging
+import os
+import subprocess
+import unittest
+
+class LatestAgeTest(unittest.TestCase):
+
+  def _get_latest_timestamp(self, repo):
+      images = json.loads(
+                subprocess.check_output(['gcloud', 'beta', 'container',
+                                         'images', 'list-tags',
+                                         '--no-show-occurrences',
+                                         '--format=json', repo]))
+      for image in images:
+          if 'latest' in image['tags']:
+              return datetime.datetime.strptime(
+                  image['timestamp']['datetime'], '%Y-%m-%d %H:%M:%S')
+      return None
+
+  def test_latest_age(self):
+      old_repos = []
+      invalid_repos = []
+      for f in glob.glob('../config/tag/*.json'):
+          # We don't care about how old these images are
+          if f.endswith('runtimes_common.json'):
+              continue
+          logging.debug('Testing {0}'.format(f))
+          with open(f) as tag_map:
+              data = json.load(tag_map)
+              for project in data['projects']:
+                  full_repo = os.path.join(project['base_registry'],
+                                           project['repository'])
+                  last_deploy = self._get_latest_timestamp(full_repo)
+                  if last_deploy is None:
+                      invalid_repos.append(full_repo)
+                  threshold = last_deploy + datetime.timedelta(weeks=2)
+                  if threshold < datetime.datetime.now():
+                      old_repos.append(full_repo)
+
+      if len(old_repos) > 0 or len(invalid_repos) > 0:
+          msg = ''
+          if len(old_repos) > 0:
+              msg += 'The following repos have not been deployed in over two weeks: {0}. '.format(str(old_repos))
+
+          if len(invalid_repos) > 0:
+              msg += 'The following repos have no latest tag: {0}.'.format(str(invalid_repos))
+
+          self.fail(msg)
+
+if __name__ == '__main__':
+  logging.basicConfig(level=logging.DEBUG)
+  unittest.main()

--- a/reconciletags/reconciletags.py
+++ b/reconciletags/reconciletags.py
@@ -32,7 +32,7 @@ class TagReconciler:
         if not dry_run:
             logging.debug('Running {0}'.format(command))
             output = subprocess.check_output([command], shell=True)
-            #logging.debug(output)
+            logging.debug(output)
             return output
         else:
             logging.debug('Would have run {0}'.format(command))
@@ -51,7 +51,7 @@ class TagReconciler:
             for tag in sublist['tags']:
                 if tag:
                     if tag == 'latest':
-                      latest = sublist['digest'][len('sha256:'):]
+                        latest = sublist['digest'][len('sha256:'):]
                     flat_tags_list.append(tag)
         return flat_tags_list, latest
 
@@ -86,8 +86,8 @@ class TagReconciler:
                     full_tag = full_repo + ':' + image['tag']
                     # Don't retag latest if it's already latest
                     if image['tag'] == 'latest' and image['digest'] == latest:
-                        logging.debug('Skipping tagging {0} as latest as it is'
-                                      'already latest.'.format(image['digest']))
+                        logging.debug('Skipping tagging %s as latest as it is '
+                                      'already latest.', image['digest'])
                         continue
                     self.add_tags(full_digest, full_tag, dry_run)
 

--- a/reconciletags/reconciletags.py
+++ b/reconciletags/reconciletags.py
@@ -32,7 +32,7 @@ class TagReconciler:
         if not dry_run:
             logging.debug('Running {0}'.format(command))
             output = subprocess.check_output([command], shell=True)
-            logging.debug(output)
+            #logging.debug(output)
             return output
         else:
             logging.debug('Would have run {0}'.format(command))
@@ -46,19 +46,22 @@ class TagReconciler:
     # This turns a list of lists into one flat list of tags
     def flatten_tags_list(self, list_of_lists):
         flat_tags_list = []
+        latest = ''
         for sublist in list_of_lists:
-            for tag in sublist:
+            for tag in sublist['tags']:
                 if tag:
+                    if tag == 'latest':
+                      latest = sublist['digest'][len('sha256:'):]
                     flat_tags_list.append(tag)
-        return flat_tags_list
+        return flat_tags_list, latest
 
     def get_existing_tags(self, repo):
         output = json.loads(self.call('gcloud beta container images list-tags '
                             '--no-show-occurrences {0}'.format(repo), False))
 
-        list_of_tags = [image['tags'] for image in output]
-        existing_tags = self.flatten_tags_list(list_of_tags)
-        return existing_tags
+        list_of_tags = [image for image in output]
+        existing_tags, latest = self.flatten_tags_list(list_of_tags)
+        return existing_tags, latest
 
     def reconcile_tags(self, data, dry_run):
         # Hardcode dry_run to False for this call because we always want
@@ -75,11 +78,17 @@ class TagReconciler:
                 full_repo = os.path.join(registry, project['repository'])
                 default_repo = os.path.join(default_registry,
                                             project['repository'])
-                logging.debug(self.get_existing_tags(full_repo))
+                existing_tags, latest = self.get_existing_tags(full_repo)
+                logging.debug(existing_tags)
 
                 for image in project['images']:
                     full_digest = default_repo + '@sha256:' + image['digest']
                     full_tag = full_repo + ':' + image['tag']
+                    # Don't retag latest if it's already latest
+                    if image['tag'] == 'latest' and image['digest'] == latest:
+                        logging.debug('Skipping tagging {0} as latest as it is'
+                                      'already latest.'.format(image['digest']))
+                        continue
                     self.add_tags(full_digest, full_tag, dry_run)
 
                 logging.debug(self.get_existing_tags(full_repo))


### PR DESCRIPTION
Changes to reconciletags.py are so when that script is run, the timestamp returned in list-tags is only updated if the latest tag was changed. That's what the new script relies on.