### PR TITLE
update google-cloud client library dependencies

### DIFF
--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-google-cloud-logging==0.21.0
-google-cloud-monitoring==0.21.0
-google-cloud-error-reporting==0.21.0
+google-cloud-logging==0.22.0
+google-cloud-monitoring==0.22.0
+google-cloud-error-reporting==0.22.0
 retrying==1.3.3

--- a/integration_tests/structure_test.yaml
+++ b/integration_tests/structure_test.yaml
@@ -14,9 +14,9 @@ commandTests:
 - name: 'pip'
   command: ['pip', 'freeze']
   expectedOutput: [
-    '.*google-cloud-logging==0\.21\.0.*',
-    '.*google-cloud-monitoring==0\.21\.0.*',
-    '.*google-cloud-error-reporting==0\.21\.0.*',
+    '.*google-cloud-logging==0\.22\.0.*',
+    '.*google-cloud-monitoring==0\.22\.0.*',
+    '.*google-cloud-error-reporting==0\.22\.0.*',
     '.*retrying==1\.3\.3.*'
   ]
 
@@ -31,7 +31,7 @@ fileExistenceTests:
   isDirectory: false
   shouldExist: false
 
-fileContentTests:  
+fileContentTests:
 - name: 'driver'
   path: '/testsuite/driver.py'
   expectedContents: ['#!/usr/bin/python.*']


### PR DESCRIPTION
this should fix an issue with retrieving the client instance in the integration tests

@dlorenc @sharifelgamal 