### PR TITLE
Add support for running custom tests through integration framework

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -29,7 +29,7 @@ Alternatively, the application can be manually deployed *before* running the tes
 		'--url', '<application_url>'
 	]
 
-In addition, each test (detailed below) can be skipped by passing the corresponding flag to the build step. For example, to opt out of the monitoring test in the run, pass the `--no-monitoring` flag to the build step.
+In addition, each test (detailed below) can be skipped by passing the corresponding flag to the build step. For example, to opt out of the monitoring test in the run, pass the `--skip-monitoring-tests` flag to the build step.
 
 ## Tests
 
@@ -113,3 +113,16 @@ The monitoring test confirms the runtime’s ability to write metrics to Stackdr
 This tests the runtime’s ability to report errors to Stackdriver. The driver will generate a request payload and POST it to the sample application. Upon receiving the payload, the application will create a Cloud Error Reporting Client. It will then use this client to report a generic exception. Additionally, it will use the client to report an exception with the provided token. Finally, it will report back to the test driver indicating that the exceptions were recorded successfully, or that an error was encountered, failing the test.
 
 At this time, there is no support within the google-cloud-python client library for reading exceptions from Stackdriver, though the public API exists. It is potentially planned to add support within this client library to do this, enabling the test driver to actually verify the specific exception was recorded in Stackdriver successfully.
+
+
+### Custom Tests
+#####` - GET http://<application_url>/custom`
+
+The integration test framework also contains support for running custom tests inside of the sample application, and reporting the results of these tests through the integration framework's report. This provides a convenient way of running standard and custom tests inside of the same test run.
+
+The test driver will make a GET request to `/custom` at the sample application's URL, and retrieve a list of test configuration specs (see below) that specify the custom tests the sample application is set up to run. The driver will then make sequential GET requests to each of these paths, each of which should contain a single custom integration test that will be run by the sample application. The application should then report back to the test driver with the results of the test, usually either an 'OK' (and 200 response code) in the event of a success, or the logs of the failed run in the event of a failure (with a 4xx or 5xx response code). These successes/failures will then be added to the integration test framework's report.
+
+Each custom test config should be a dictionary that contains three fields:
+	* `name` (optional): the name of the test
+	* `path` (required): the path at which the test can be accessed
+	* `timeout` (optional): the amount of time (in ms) to wait before the test fails

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -122,7 +122,7 @@ The integration test framework also contains support for running custom tests in
 
 The test driver will make a GET request to `/custom` at the sample application's URL, and retrieve a list of test configuration specs (see below) that specify the custom tests the sample application is set up to run. The driver will then make sequential GET requests to each of these paths, each of which should contain a single custom integration test that will be run by the sample application. The application should then report back to the test driver with the results of the test, usually either an 'OK' (and 200 response code) in the event of a success, or the logs of the failed run in the event of a failure (with a 4xx or 5xx response code). These successes/failures will then be added to the integration test framework's report.
 
-Each custom test config should be a dictionary that contains three fields:
+Each custom test config should be a JSON map that contains three fields:
 	* `name` (optional): the name of the test
 	* `path` (required): the path at which the test can be accessed
-	* `timeout` (optional): the amount of time (in ms) to wait before the test fails
+	* `timeout` (optional): the amount of time (in ms) to wait before the test fails. default value is 500ms.

--- a/integration_tests/testsuite/driver.py
+++ b/integration_tests/testsuite/driver.py
@@ -59,10 +59,10 @@ def _main():
                         action='store_false',
                         dest='exception',
                         help='Flag to skip error reporting tests')
-    parser.add_argument('--custom-tests',
-                        action='store_true',
+    parser.add_argument('--skip-custom-tests',
+                        action='store_false',
                         dest='custom',
-                        help='Flag to run custom integration tests')
+                        help='Flag to skip custom integration tests')
     parser.add_argument('--url', '-u',
                         help='URL where deployed app is ' +
                         'exposed (if applicable)')

--- a/integration_tests/testsuite/driver.py
+++ b/integration_tests/testsuite/driver.py
@@ -20,6 +20,7 @@ import sys
 import unittest
 
 from deploy_app import deploy_app
+import test_custom
 import test_exception
 import test_logging_standard
 import test_logging_custom
@@ -58,6 +59,10 @@ def _main():
                         action='store_false',
                         dest='exception',
                         help='Flag to skip error reporting tests')
+    parser.add_argument('--custom-tests',
+                        action='store_true',
+                        dest='custom',
+                        help='Flag to run custom integration tests')
     parser.add_argument('--url', '-u',
                         help='URL where deployed app is ' +
                         'exposed (if applicable)')
@@ -108,6 +113,9 @@ def _test_app(base_url, args):
 
     if args.exception:
         suite.addTest(test_exception.TestException(base_url))
+
+    if args.custom:
+        suite.addTest(test_custom.TestCustom(base_url))
 
     return not unittest.TextTestRunner(verbosity=4).run(suite).wasSuccessful()
 

--- a/integration_tests/testsuite/test_custom.py
+++ b/integration_tests/testsuite/test_custom.py
@@ -46,6 +46,3 @@ class TestCustom(unittest.TestCase):
             response, code = test_util.get(full_endpoint, timeout=timeout)
 
             logging.debug(response)
-
-
-

--- a/integration_tests/testsuite/test_custom.py
+++ b/integration_tests/testsuite/test_custom.py
@@ -2,37 +2,50 @@
 
 # Copyright 2017 Google Inc. All rights reserved.
 
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import unittest
+from retrying import retry
 
 import test_util
 
 
-class TestRoot(unittest.TestCase):
+class TestCustom(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
-        self._url = url + test_util.ROOT_ENDPOINT
+        self._base_url = url
+        self._url = url + test_util.CUSTOM_ENDPOINT
         unittest.TestCase.__init__(self)
 
     def runTest(self):
-        logging.debug('Hitting endpoint: {0}'.format(self._url))
+        logging.debug('Retrieving list of custom test endpoints.')
         output, status_code = test_util.get(self._url)
-        logging.info('output is: {0}'.format(output))
         self.assertEquals(status_code, 0,
                           'Cannot connect to sample application!')
 
-        self.assertEquals(output, test_util.ROOT_EXPECTED_OUTPUT,
-                          'Unexpected output: expected {0}, received {1}'
-                          .format(test_util.ROOT_EXPECTED_OUTPUT, output))
+        logging.debug('output: {0}'.format(output))
+
+        for endpoint_info in json.loads(output):
+            endpoint = endpoint_info[0]
+            timeout = endpoint_info[1]
+
+            full_endpoint = self._base_url + endpoint
+            logging.info('making get request to {0}'.format(full_endpoint))
+            response, code = test_util.get(full_endpoint, timeout=timeout)
+
+            logging.debug(response)
+
+
+

--- a/integration_tests/testsuite/test_custom.py
+++ b/integration_tests/testsuite/test_custom.py
@@ -17,6 +17,7 @@
 import json
 import logging
 import unittest
+from urlparse import urljoin
 from retrying import retry
 
 import test_util
@@ -35,8 +36,6 @@ class TestCustom(unittest.TestCase):
         self.assertEquals(status_code, 0,
                           'Cannot connect to sample application!')
 
-        logging.debug('output: {0}'.format(output))
-
         test_num = 0
         for test_info in json.loads(output):
             test_num+=1
@@ -49,7 +48,7 @@ class TestCustom(unittest.TestCase):
 
             timeout = test_info.get('timeout', 500)
 
-            test_endpoint = self._base_url + path
+            test_endpoint = urljoin(self._base_url, path)
             logging.info('Running custom test: {0}'.format(name))
             response, code = test_util.get(test_endpoint, timeout=timeout)
 

--- a/integration_tests/testsuite/test_custom.py
+++ b/integration_tests/testsuite/test_custom.py
@@ -17,7 +17,7 @@
 import json
 import logging
 import unittest
-from urlparse import urljoin
+import urlparse
 
 import test_util
 
@@ -26,7 +26,7 @@ class TestCustom(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
         self._base_url = url
-        self._url = urljoin(url, test_util.CUSTOM_ENDPOINT)
+        self._url = urlparse.urljoin(url, test_util.CUSTOM_ENDPOINT)
         unittest.TestCase.__init__(self)
 
     def runTest(self):
@@ -47,7 +47,7 @@ class TestCustom(unittest.TestCase):
 
             timeout = test_info.get('timeout', 500)
 
-            test_endpoint = urljoin(self._base_url, path)
+            test_endpoint = urlparse.urljoin(self._base_url, path)
             logging.info('Running custom test: {0}'.format(name))
             response, code = test_util.get(test_endpoint, timeout=timeout)
 

--- a/integration_tests/testsuite/test_custom.py
+++ b/integration_tests/testsuite/test_custom.py
@@ -37,12 +37,20 @@ class TestCustom(unittest.TestCase):
 
         logging.debug('output: {0}'.format(output))
 
-        for endpoint_info in json.loads(output):
-            endpoint = endpoint_info[0]
-            timeout = endpoint_info[1]
+        test_num = 0
+        for test_info in json.loads(output):
+            test_num+=1
+            name = test_info.get('name', 'test_{0}'.format(test_num))
+            path = test_info.get('path')
+            if path is None:
+                logging.warn('Test \'{0}\' has no path specified! '
+                             'Skipping...'.format(name))
+                continue
 
-            full_endpoint = self._base_url + endpoint
-            logging.info('making get request to {0}'.format(full_endpoint))
-            response, code = test_util.get(full_endpoint, timeout=timeout)
+            timeout = test_info.get('timeout', 500)
+
+            test_endpoint = self._base_url + path
+            logging.info('Running custom test: {0}'.format(name))
+            response, code = test_util.get(test_endpoint, timeout=timeout)
 
             logging.debug(response)

--- a/integration_tests/testsuite/test_custom.py
+++ b/integration_tests/testsuite/test_custom.py
@@ -26,7 +26,7 @@ class TestCustom(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
         self._base_url = url
-        self._url = url + test_util.CUSTOM_ENDPOINT
+        self._url = urljoin(url, test_util.CUSTOM_ENDPOINT)
         unittest.TestCase.__init__(self)
 
     def runTest(self):

--- a/integration_tests/testsuite/test_custom.py
+++ b/integration_tests/testsuite/test_custom.py
@@ -18,7 +18,6 @@ import json
 import logging
 import unittest
 from urlparse import urljoin
-from retrying import retry
 
 import test_util
 
@@ -38,7 +37,7 @@ class TestCustom(unittest.TestCase):
 
         test_num = 0
         for test_info in json.loads(output):
-            test_num+=1
+            test_num += 1
             name = test_info.get('name', 'test_{0}'.format(test_num))
             path = test_info.get('path')
             if path is None:

--- a/integration_tests/testsuite/test_exception.py
+++ b/integration_tests/testsuite/test_exception.py
@@ -28,7 +28,7 @@ class TestException(unittest.TestCase):
 
     def runTest(self):
         payload = test_util.generate_exception_payload()
-        _, response_code = test_util._post(self._url, payload)
+        _, response_code = test_util.post(self._url, payload)
         self.assertEquals(response_code, 0,
                           'Error encountered inside sample application!')
         logging.info('Token {0} written to Stackdriver '

--- a/integration_tests/testsuite/test_exception.py
+++ b/integration_tests/testsuite/test_exception.py
@@ -16,6 +16,7 @@
 
 import logging
 import unittest
+from urlparse import urljoin
 
 import test_util
 
@@ -23,7 +24,7 @@ import test_util
 class TestException(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
-        self._url = url + test_util.EXCEPTION_ENDPOINT
+        self._url = urljoin(url, test_util.EXCEPTION_ENDPOINT)
         unittest.TestCase.__init__(self)
 
     def runTest(self):

--- a/integration_tests/testsuite/test_exception.py
+++ b/integration_tests/testsuite/test_exception.py
@@ -16,7 +16,7 @@
 
 import logging
 import unittest
-from urlparse import urljoin
+import urlparse
 
 import test_util
 
@@ -24,8 +24,8 @@ import test_util
 class TestException(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
-        self._url = urljoin(url, test_util.EXCEPTION_ENDPOINT)
-        unittest.TestCase.__init__(self)
+        self._url = urlparse.urljoin(url, test_util.EXCEPTION_ENDPOINT)
+        super(TestException, self).__init__()
 
     def runTest(self):
         payload = test_util.generate_exception_payload()

--- a/integration_tests/testsuite/test_logging.py
+++ b/integration_tests/testsuite/test_logging.py
@@ -16,7 +16,7 @@
 
 import logging
 import unittest
-from urlparse import urljoin
+import urlparse
 from retrying import retry
 
 import google.cloud.logging
@@ -27,7 +27,7 @@ import test_util
 class TestLogging(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
-        self._url = urljoin(url, test_util.LOGGING_ENDPOINT)
+        self._url = urlparse.urljoin(url, test_util.LOGGING_ENDPOINT)
         unittest.TestCase.__init__(self)
 
     def runTest(self):

--- a/integration_tests/testsuite/test_logging.py
+++ b/integration_tests/testsuite/test_logging.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import unittest
+from retrying import retry
+
+import google.cloud.logging
+
+import test_util
+
+
+class TestLogging(unittest.TestCase):
+
+    def __init__(self, url, methodName='runTest'):
+        self._url = url + test_util.LOGGING_ENDPOINT
+        unittest.TestCase.__init__(self)
+
+    def runTest(self):
+        logging.debug('Posting to endpoint: {0}'.format(self._url))
+
+        payload = test_util.generate_logging_payload()
+        if test_util.post(self._url, payload) != 0:
+            return self.fail('Error encountered inside sample application!')
+
+        client = google.cloud.logging.Client()
+        log_name = payload.get('log_name')
+        token = payload.get('token')
+
+        logging.info('log name is {0}, '
+                     'token is {1}'.format(log_name, token))
+
+        project_id = test_util._project_id()
+        FILTER = 'logName = projects/{0}/logs/' \
+                 'appengine.googleapis.com%2Fstdout'.format(project_id)
+
+        self.assertTrue(self._read_log(client, log_name, token, FILTER),
+                        'Log entry not found for posted token!')
+
+    @retry(wait_fixed=4000, stop_max_attempt_number=8)
+    def _read_log(self, client, log_name, token, filter):
+        for entry in client.list_entries(filter_=filter):
+                if token in entry.payload:
+                    logging.info('Token {0} found in '
+                                 'Stackdriver logs!'.format(token))
+                    return True
+        raise Exception('Log entry not found for posted token!')

--- a/integration_tests/testsuite/test_logging.py
+++ b/integration_tests/testsuite/test_logging.py
@@ -16,6 +16,7 @@
 
 import logging
 import unittest
+from urlparse import urljoin
 from retrying import retry
 
 import google.cloud.logging
@@ -26,7 +27,7 @@ import test_util
 class TestLogging(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
-        self._url = url + test_util.LOGGING_ENDPOINT
+        self._url = urljoin(url, test_util.LOGGING_ENDPOINT)
         unittest.TestCase.__init__(self)
 
     def runTest(self):

--- a/integration_tests/testsuite/test_logging_custom.py
+++ b/integration_tests/testsuite/test_logging_custom.py
@@ -27,7 +27,7 @@ class TestCustomLogging(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
         self._url = url + test_util.CUSTOM_LOGGING_ENDPOINT
-        unittest.TestCase.__init__(self)
+        super(TestCustomLogging, self).__init__()
 
     def runTest(self):
         logging.debug('Posting to endpoint: {0}'.format(self._url))

--- a/integration_tests/testsuite/test_logging_custom.py
+++ b/integration_tests/testsuite/test_logging_custom.py
@@ -34,7 +34,7 @@ class TestCustomLogging(unittest.TestCase):
 
         payloads = test_util.generate_logging_payloads()
         for payload in payloads:
-            _, response_code = test_util._post(self._url, payload)
+            _, response_code = test_util.post(self._url, payload)
             if response_code != 0:
                 self.fail('Error encountered inside '
                           'sample application!')

--- a/integration_tests/testsuite/test_logging_standard.py
+++ b/integration_tests/testsuite/test_logging_standard.py
@@ -34,7 +34,7 @@ class TestStandardLogging(unittest.TestCase):
 
         payloads = test_util.generate_logging_payloads()
         for payload in payloads:
-            log_name, response_code = test_util._post(self._url, payload)
+            log_name, response_code = test_util.post(self._url, payload)
             if response_code != 0:
                 self.fail('Error encountered inside '
                           'sample application!')

--- a/integration_tests/testsuite/test_logging_standard.py
+++ b/integration_tests/testsuite/test_logging_standard.py
@@ -27,7 +27,7 @@ class TestStandardLogging(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
         self._url = url + test_util.STANDARD_LOGGING_ENDPOINT
-        unittest.TestCase.__init__(self)
+        super(TestStandardLogging, self).__init__()
 
     def runTest(self):
         logging.debug('Posting to endpoint: {0}'.format(self._url))

--- a/integration_tests/testsuite/test_monitoring.py
+++ b/integration_tests/testsuite/test_monitoring.py
@@ -31,7 +31,7 @@ class TestMonitoring(unittest.TestCase):
 
     def runTest(self):
         payload = test_util.generate_metrics_payload()
-        _, response_code = test_util._post(self._url, payload,
+        _, response_code = test_util.post(self._url, payload,
                                            test_util.METRIC_TIMEOUT)
         self.assertEquals(response_code, 0,
                           'Error encountered inside sample application!')

--- a/integration_tests/testsuite/test_monitoring.py
+++ b/integration_tests/testsuite/test_monitoring.py
@@ -17,7 +17,7 @@
 import logging
 from retrying import retry
 import unittest
-from urlparse import urljoin
+import urlparse
 
 import google.cloud.monitoring
 
@@ -27,8 +27,8 @@ import test_util
 class TestMonitoring(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
-        self._url = urljoin(url, test_util.MONITORING_ENDPOINT)
-        unittest.TestCase.__init__(self)
+        self._url = urlparse.urljoin(url, test_util.MONITORING_ENDPOINT)
+        super(TestMonitoring, self).__init__()
 
     def runTest(self):
         payload = test_util.generate_metrics_payload()

--- a/integration_tests/testsuite/test_monitoring.py
+++ b/integration_tests/testsuite/test_monitoring.py
@@ -17,6 +17,7 @@
 import logging
 from retrying import retry
 import unittest
+from urlparse import urljoin
 
 import google.cloud.monitoring
 
@@ -26,7 +27,7 @@ import test_util
 class TestMonitoring(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
-        self._url = url + test_util.MONITORING_ENDPOINT
+        self._url = urljoin(url, test_util.MONITORING_ENDPOINT)
         unittest.TestCase.__init__(self)
 
     def runTest(self):

--- a/integration_tests/testsuite/test_monitoring.py
+++ b/integration_tests/testsuite/test_monitoring.py
@@ -33,7 +33,7 @@ class TestMonitoring(unittest.TestCase):
     def runTest(self):
         payload = test_util.generate_metrics_payload()
         _, response_code = test_util.post(self._url, payload,
-                                           test_util.METRIC_TIMEOUT)
+                                          test_util.METRIC_TIMEOUT)
         self.assertEquals(response_code, 0,
                           'Error encountered inside sample application!')
 

--- a/integration_tests/testsuite/test_root.py
+++ b/integration_tests/testsuite/test_root.py
@@ -16,6 +16,7 @@
 
 import logging
 import unittest
+from urlparse import urljoin
 
 import test_util
 
@@ -23,7 +24,7 @@ import test_util
 class TestRoot(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
-        self._url = url + test_util.ROOT_ENDPOINT
+        self._url = urljoin(url, test_util.ROOT_ENDPOINT)
         unittest.TestCase.__init__(self)
 
     def runTest(self):

--- a/integration_tests/testsuite/test_root.py
+++ b/integration_tests/testsuite/test_root.py
@@ -16,7 +16,7 @@
 
 import logging
 import unittest
-from urlparse import urljoin
+import urlparse
 
 import test_util
 
@@ -24,8 +24,8 @@ import test_util
 class TestRoot(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
-        self._url = urljoin(url, test_util.ROOT_ENDPOINT)
-        unittest.TestCase.__init__(self)
+        self._url = urlparse.urljoin(url, test_util.ROOT_ENDPOINT)
+        super(TestRoot, self).__init__()
 
     def runTest(self):
         logging.debug('Hitting endpoint: {0}'.format(self._url))

--- a/integration_tests/testsuite/test_util.py
+++ b/integration_tests/testsuite/test_util.py
@@ -36,6 +36,7 @@ STANDARD_LOGGING_ENDPOINT = '/logging_standard'
 CUSTOM_LOGGING_ENDPOINT = '/logging_custom'
 MONITORING_ENDPOINT = '/monitoring'
 EXCEPTION_ENDPOINT = '/exception'
+CUSTOM_ENDPOINT = '/custom'
 
 METRIC_PREFIX = 'custom.googleapis.com/{0}'
 METRIC_TIMEOUT = 60  # seconds
@@ -87,7 +88,7 @@ def generate_exception_payload():
     return data
 
 
-def _get(url, timeout=DEFAULT_TIMEOUT):
+def get(url, timeout=DEFAULT_TIMEOUT):
     logging.info('making get request to url {0}'.format(url))
     try:
         response = requests.get(url)
@@ -101,7 +102,7 @@ def _get(url, timeout=DEFAULT_TIMEOUT):
         return None, 1
 
 
-def _post(url, payload, timeout=DEFAULT_TIMEOUT):
+def post(url, payload, timeout=DEFAULT_TIMEOUT):
     try:
         headers = {'Content-Type': 'application/json'}
         response = requests.post(url,

--- a/integration_tests/testsuite/test_util.py
+++ b/integration_tests/testsuite/test_util.py
@@ -89,13 +89,14 @@ def generate_exception_payload():
 
 
 def get(url, timeout=DEFAULT_TIMEOUT):
-    logging.info('making get request to url {0}'.format(url))
+    logging.info('Making GET request to url {0}'.format(url))
     try:
         response = requests.get(url)
-        return _check_response(response,
-                               'error when making get ' +
-                               'request! url: {0}'
-                               .format(url))
+        logging.debug('Response: {0}'.format(response.content))
+        return response.content, _check_response(response,
+                                                 'error when making get ' +
+                                                 'request! url: {0}'
+                                                 .format(url))
     except Exception as e:
         logging.error('Error encountered when making get request!')
         logging.error(e)

--- a/integration_tests/testsuite/test_util.py
+++ b/integration_tests/testsuite/test_util.py
@@ -93,7 +93,7 @@ def get(url, timeout=DEFAULT_TIMEOUT):
     try:
         response = requests.get(url)
         logging.debug('Response: {0}'.format(response.content))
-        return response.content, _check_response(response,
+        return _check_response(response,
                                                  'error when making get ' +
                                                  'request! url: {0}'
                                                  .format(url))

--- a/integration_tests/testsuite/test_util.py
+++ b/integration_tests/testsuite/test_util.py
@@ -94,9 +94,9 @@ def get(url, timeout=DEFAULT_TIMEOUT):
         response = requests.get(url)
         logging.debug('Response: {0}'.format(response.content))
         return _check_response(response,
-                                                 'error when making get ' +
-                                                 'request! url: {0}'
-                                                 .format(url))
+                               'error when making get ' +
+                               'request! url: {0}'
+                               .format(url))
     except Exception as e:
         logging.error('Error encountered when making get request!')
         logging.error(e)


### PR DESCRIPTION
This PR allows runtime maintainers to run custom integration tests through the standard integration testing framework, by exposing their tests at unused URLs in their sample application. These URLs will be retrieved by the test driver at `/custom`, then poked sequentially by the driver which will be returned the output of each test by the sample application. See the README for more details.

@dlorenc 