### PR TITLE
Add containerFromRun for exec instruction

### DIFF
--- a/docgen/lib/proto/docgen.proto
+++ b/docgen/lib/proto/docgen.proto
@@ -300,7 +300,12 @@ message ExecInstruction {
   ExecType exec_type = 1;
 
   // Name of the container to exec within. Required.
-  string container_name = 2;
+  oneof container_name_oneof {
+    // Specifies the container name directly.
+    string container_name = 2;
+    // Gets the container name from the run instruction.
+    RunInstruction container_from_run = 6;
+  }
 
   // Full exec command. Required.
   string command = 3;

--- a/docgen/lib/render/enhanced.go
+++ b/docgen/lib/render/enhanced.go
@@ -564,6 +564,14 @@ func (t *ExecInstruction) Interactive() bool {
 	return t.ExecType == proto.ExecInstruction_INTERACTIVE_SHELL
 }
 
+func (t *ExecInstruction) ContainerName() string {
+	if t.GetContainerFromRun() != nil {
+		runInstruction := &RunInstruction{t.GetContainerFromRun(), t.Runtime, t.TaskInstruction}
+		return runInstruction.ContainerName()
+	}
+	return t.GetContainerName()
+}
+
 type PortReference struct {
 	*proto.PortReference
 }


### PR DESCRIPTION
The container name will be derived from the specified run
instruction. Before, the user had to specify a hard-coded name.