### PR TITLE
run command in shell mode if it fails to start

### DIFF
--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"reflect"
 	"syscall"
 	"testing"
 )
@@ -187,13 +186,12 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string, checkO
 		} else {
 			t.Fatalf("Error running setup/teardown command: %s.", err)
 		}
-		errType := reflect.TypeOf(err)
-		t.Logf("err type is %s", errType.String())
 
 		exitErr, ok := err.(*exec.ExitError)
 		if !ok {
-			t.Logf("Command failed to run!")
-			exitCode = 12345
+			t.Logf("Command failed to run! Attempting to run in shell mode.")
+			shellCommand := append([]string{"sh", "-c"}, fullCommand...)
+			return ProcessCommand(t, envVars, shellCommand, checkOutput)
 		} else {
 			exitCode = exitErr.Sys().(syscall.WaitStatus).ExitStatus()
 		}

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -191,7 +191,7 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string, checkO
 		if !ok {
 			exitErr, ok := err.(*exec.Error)
 			if ok {
-				t.Logf("Command %s failed to run! Error: %s", exitErr.Name, exitErr.Error)
+				t.Logf("Command %s failed to run! Error: %s", exitErr.Name, exitErr.Error())
 				t.Logf("Attempting to run in shell mode.")
 			} else {
 				t.Logf("Command failed to run! Unable to retrieve error info!")

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -189,7 +189,13 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string, checkO
 
 		exitErr, ok := err.(*exec.ExitError)
 		if !ok {
-			t.Logf("Command failed to run! Attempting to run in shell mode.")
+			exitErr, ok := err.(*exec.Error)
+			if ok {
+				t.Logf("Command %s failed to run! Error: %s", exitErr.Name, exitErr.Error)
+				t.Logf("Attempting to run in shell mode.")
+			} else {
+				t.Logf("Command failed to run! Unable to retrieve error info!")
+			}
 			shellCommand := append([]string{"sh", "-c"}, fullCommand...)
 			return ProcessCommand(t, envVars, shellCommand, checkOutput)
 		} else {

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"reflect"
 	"syscall"
 	"testing"
 )
@@ -186,7 +187,16 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string, checkO
 		} else {
 			t.Fatalf("Error running setup/teardown command: %s.", err)
 		}
-		exitCode = err.(*exec.ExitError).Sys().(syscall.WaitStatus).ExitStatus()
+		errType := reflect.TypeOf(err)
+		t.Logf("err type is %s", errType.String())
+
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Logf("Command failed to run!")
+			exitCode = 12345
+		} else {
+			exitCode = exitErr.Sys().(syscall.WaitStatus).ExitStatus()
+		}
 	} else {
 		exitCode = cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 	}


### PR DESCRIPTION
If a test command fails to start, we can attempt to run it in shell mode to retrieve the exit code of the actual shell process. This allows us to test intentionally bad commands, and retrieve an exit code like 127 (what Linux will return if a process fails to start).

Fixes #74 

@dlorenc 