### PR TITLE
add support for running commands in shell mode

### DIFF
--- a/check_if_image_tag_exists/cloudbuild.yaml.in
+++ b/check_if_image_tag_exists/cloudbuild.yaml.in
@@ -3,6 +3,6 @@ steps:
     args: ['build', '--tag=${IMAGE}', '.']
     id: BUILD
   - name: gcr.io/gcp-runtimes/structure_test:latest
-    args: ['--image', '${IMAGE}', '-v', '--config', '/workspace/test_config.json']
+    args: ['--image', '${IMAGE}', '-v', '--config', '/workspace/structure_test.yaml']
     id: STRUCTURE_TEST
 images: ['${IMAGE}']

--- a/check_if_image_tag_exists/structure_test.yaml
+++ b/check_if_image_tag_exists/structure_test.yaml
@@ -11,6 +11,11 @@ commandTests:
   exitCode: 1
   expectedError: ['.*[invalid | unrecognized].*']
 
+- name: 'Non-existent Binary in Shell Mode'
+  command: ['asdf']
+  shellMode: true
+  exitCode: 127
+
 fileExistenceTests:
 - name: 'Root'
   path: '/'

--- a/check_if_image_tag_exists/structure_test.yaml
+++ b/check_if_image_tag_exists/structure_test.yaml
@@ -16,6 +16,10 @@ commandTests:
   shellMode: true
   exitCode: 127
 
+- name: 'Non-existent Binary'
+  command: ['asdf']
+  expectedError: ['.*not found.*']
+
 fileExistenceTests:
 - name: 'Root'
   path: '/'

--- a/structure_tests/README.md
+++ b/structure_tests/README.md
@@ -31,6 +31,7 @@ Command tests ensure that certain commands run properly on top of the shell of t
 - Expected Error ([]string, *optional*): List of regexes that should match the stderr from running the command.
 - Excluded Error ([]string, *optional*): List of regexes that should **not** match the stderr from running the command.
 - Exit Code (int, *optional*): Exit code that the command should exit with.
+- Shell Mode (bool, *optional*): Whether or not to run the specified command in a new shell. Useful for testing whether or not a binary exists, and retrieving useful information from the error if not.
 
 Example:
 ```json
@@ -48,7 +49,14 @@ Example:
                 "command": ["node", "-v"],
                 "expectedOutput": ["v5.9.0\n"],
                 "exitCode": 0
+        },
+        {
+                "name": "Non-Existent Binary in Shell Mode",
+                "command": ["which", "asdf"],
+                "exitCode": 127,
+                "shellMode", true
         }
+      }
 ]
 ```
 

--- a/structure_tests/README.md
+++ b/structure_tests/README.md
@@ -54,9 +54,8 @@ Example:
                 "name": "Non-Existent Binary in Shell Mode",
                 "command": ["which", "asdf"],
                 "exitCode": 127,
-                "shellMode", true
+                "shellMode": true
         }
-      }
 ]
 ```
 

--- a/structure_tests/command_test_v1.go
+++ b/structure_tests/command_test_v1.go
@@ -25,6 +25,7 @@ type CommandTestv1 struct {
 	Teardown       []Command
 	EnvVars        []EnvVar
 	ExitCode       int
+	ShellMode      bool
 	Command        []string
 	ExpectedOutput []string
 	ExcludedOutput []string

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -154,7 +154,7 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string,
 	var flags []string
 	if shellMode {
 		command = "sh"
-		flags = []string{"-c", strings.Join(fullCommand[0:], " ")}
+		flags = []string{"-c", strings.Join(fullCommand, " ")}
 	} else {
 		command = fullCommand[0]
 		flags = fullCommand[1:]

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -195,17 +195,14 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string,
 		} else {
 			t.Fatalf("Error running setup/teardown command: %s.", err)
 		}
-		exitErr, ok := err.(*exec.ExitError)
-		if ok {
-			exitCode = exitErr.Sys().(syscall.WaitStatus).ExitStatus()
-		} else {
-			exitErr, ok := err.(*exec.Error)
-			if ok {
-				// Command started but failed to finish, so we can at least check the stderr
-				stderr = exitErr.Error()
-			} else {
-				t.Errorf("Command failed to start! Unable to retrieve error info!")
-			}
+		switch err := err.(type) {
+		default:
+			t.Errorf("Command failed to start! Unable to retrieve error info!")
+		case *exec.ExitError:
+			exitCode = err.Sys().(syscall.WaitStatus).ExitStatus()
+		case *exec.Error:
+			// Command started but failed to finish, so we can at least check the stderr
+			stderr = err.Error()
 		}
 	} else {
 		exitCode = cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 )
@@ -49,14 +50,14 @@ func (st StructureTestv1) RunCommandTests(t *testing.T) int {
 		t.Run(tt.LogName(), func(t *testing.T) {
 			validateCommandTestV1(t, tt)
 			for _, setup := range tt.Setup {
-				ProcessCommand(t, tt.EnvVars, setup, false)
+				ProcessCommand(t, tt.EnvVars, setup, tt.ShellMode, false)
 			}
 
-			stdout, stderr, exitcode := ProcessCommand(t, tt.EnvVars, tt.Command, true)
+			stdout, stderr, exitcode := ProcessCommand(t, tt.EnvVars, tt.Command, tt.ShellMode, true)
 			CheckOutput(t, tt, stdout, stderr, exitcode)
 
 			for _, teardown := range tt.Teardown {
-				ProcessCommand(t, tt.EnvVars, teardown, false)
+				ProcessCommand(t, tt.EnvVars, teardown, tt.ShellMode, false)
 			}
 			counter++
 		})
@@ -142,14 +143,22 @@ func (st StructureTestv1) RunLicenseTests(t *testing.T) int {
 // current environment. a list of environment variables can be passed to be set in the
 // environment before the command is executed. additionally, a boolean flag is passed
 // to specify whether or not we care about the output of the command.
-func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string, checkOutput bool) (string, string, int) {
+func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string,
+					shellMode bool, checkOutput bool) (string, string, int) {
 	var cmd *exec.Cmd
 	if len(fullCommand) == 0 {
 		t.Logf("empty command provided: skipping...")
 		return "", "", -1
 	}
-	command := fullCommand[0]
-	flags := fullCommand[1:]
+	var command string
+	var flags []string
+	if shellMode {
+		command = "sh"
+		flags = []string{"-c", strings.Join(fullCommand[0:], " ")}
+	} else {
+		command = fullCommand[0]
+		flags = fullCommand[1:]
+	}
 	originalVars := SetEnvVars(t, envVars)
 	defer ResetEnvVars(t, originalVars)
 	if len(flags) > 0 {

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -144,7 +144,7 @@ func (st StructureTestv1) RunLicenseTests(t *testing.T) int {
 // environment before the command is executed. additionally, a boolean flag is passed
 // to specify whether or not we care about the output of the command.
 func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string,
-					shellMode bool, checkOutput bool) (string, string, int) {
+	shellMode bool, checkOutput bool) (string, string, int) {
 	var cmd *exec.Cmd
 	if len(fullCommand) == 0 {
 		t.Logf("empty command provided: skipping...")
@@ -153,7 +153,7 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string,
 	var command string
 	var flags []string
 	if shellMode {
-		command = "sh"
+		command = "/bin/sh"
 		flags = []string{"-c", strings.Join(fullCommand, " ")}
 	} else {
 		command = fullCommand[0]

--- a/structure_tests/structure_test_v1.go
+++ b/structure_tests/structure_test_v1.go
@@ -195,7 +195,18 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string,
 		} else {
 			t.Fatalf("Error running setup/teardown command: %s.", err)
 		}
-		exitCode = err.(*exec.ExitError).Sys().(syscall.WaitStatus).ExitStatus()
+		exitErr, ok := err.(*exec.ExitError)
+		if ok {
+			exitCode = exitErr.Sys().(syscall.WaitStatus).ExitStatus()
+		} else {
+			exitErr, ok := err.(*exec.Error)
+			if ok {
+				// Command started but failed to finish, so we can at least check the stderr
+				stderr = exitErr.Error()
+			} else {
+				t.Errorf("Command failed to start! Unable to retrieve error info!")
+			}
+		}
 	} else {
 		exitCode = cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 	}


### PR DESCRIPTION
alternate take on https://github.com/GoogleCloudPlatform/runtimes-common/pull/138, which will allow people to test intentionally malformed commands on binaries that may or may not exist, with correct error codes.

fixes #74 

@dlorenc 