### PR TITLE
Add exit code, substitutions, and regex

### DIFF
--- a/functional_tests/README.md
+++ b/functional_tests/README.md
@@ -114,6 +114,7 @@ Expectations on STDOUT and STDERR can use zero or more of the following attribut
 |---|---|
 | equals | String. The output is trimmed before comparing. |
 | exactly | String. The output is compared verbatim. |
+| matches | String. The output must _partially_ match the regex defined. |
 | mustBeEmpty | Boolean. If true, no output is expected. |
 
 For example:

--- a/functional_tests/README.md
+++ b/functional_tests/README.md
@@ -137,6 +137,13 @@ tests:
       mustBeEmpty: true
 ```
 
+## Substitutions
+
+Test commands can use substitutions, which are specified in the test spec as
+shell variable substitutions `${VAR_NAME}` or `$VAR_NAME`. The values of the
+variables are specified in the command line argument `--vars VAR_NAME=value`.
+This arugment can be specified multiple times.
+
 # Development
 
 `examples/build-and-run/cloudbuild.yaml` conveniently builds this image and run

--- a/functional_tests/src/runtest/asserts.go
+++ b/functional_tests/src/runtest/asserts.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -31,6 +32,15 @@ func DoStringAssert(value string, rule StringAssert) string {
 		trimmed := strings.TrimSpace(value)
 		if trimmed != rule.Equals {
 			return fmt.Sprintf("Should have been:\n%s\n... but was:\n%s", rule.Equals, trimmed)
+		}
+	}
+	if len(rule.Matches) > 0 {
+		r, err := regexp.Compile(rule.Matches)
+		if err != nil {
+			return fmt.Sprintf("Regex failed to compile: %s", rule.Matches)
+		}
+		if !r.MatchString(value) {
+			return fmt.Sprintf("Should have matched regex:\n%s\n... but was:\n%s", rule.Matches, value)
 		}
 	}
 	if rule.MustBeEmpty {

--- a/functional_tests/src/runtest/asserts_test.go
+++ b/functional_tests/src/runtest/asserts_test.go
@@ -36,6 +36,18 @@ func TestStringAssertEquals(t *testing.T) {
 	assertShouldFail(t, "to be equal\nbut", rule)
 }
 
+func TestStringAssertMatches(t *testing.T) {
+	rule := StringAssert{Matches: "a[bc]d"}
+	assertShouldPass(t, "abd", rule)
+	assertShouldPass(t, "123acd456", rule)
+	assertShouldFail(t, "ad", rule)
+}
+
+func TestStringAssertMatchesBadRegex(t *testing.T) {
+	rule := StringAssert{Matches: `\`}
+	assertShouldFail(t, `\`, rule)
+}
+
 func TestStringAssertMustBeEmpty(t *testing.T) {
 	rule := StringAssert{MustBeEmpty: true}
 	assertShouldPass(t, "", rule)
@@ -45,13 +57,15 @@ func TestStringAssertMustBeEmpty(t *testing.T) {
 func assertShouldPass(t *testing.T, value string, rule StringAssert) {
 	outcome := DoStringAssert(value, rule)
 	if len(outcome) > 0 {
-		t.Errorf("Expected to pass, but failed with error: %s", outcome)
+		t.Errorf("Expected to pass for string: %s\n...but failed with error: %s", value, outcome)
 	}
 }
 
 func assertShouldFail(t *testing.T, value string, rule StringAssert) {
 	outcome := DoStringAssert(value, rule)
 	if len(outcome) == 0 {
-		t.Error("Expected to fail but was passing")
+		t.Errorf("Expected to fail but was passing for string: %s", value)
+	} else {
+		t.Logf("DoStringAssert() output: %s", outcome)
 	}
 }

--- a/functional_tests/src/runtest/flags.go
+++ b/functional_tests/src/runtest/flags.go
@@ -1,0 +1,46 @@
+// Copyright 2017 Google Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"strings"
+)
+
+type StringMapFlag map[string]string
+
+func (m *StringMapFlag) String() string {
+	return fmt.Sprintf("StringMapFlag%v", *m)
+}
+
+func (m *StringMapFlag) Set(value string) error {
+	split := strings.SplitN(value, "=", 2)
+	if len(split) != 2 {
+		return errors.New("Invalid flag format. Value should be key=value")
+	}
+	if *m == nil {
+		*m = make(map[string]string)
+	}
+	(*m)[split[0]] = split[1]
+	return nil
+}
+
+func FlagStringMap(name string, usage string) *map[string]string {
+	var f StringMapFlag
+	flag.Var(&f, name, usage)
+	return (*map[string]string)(&f)
+}

--- a/functional_tests/src/runtest/specs.go
+++ b/functional_tests/src/runtest/specs.go
@@ -52,6 +52,7 @@ type Expect struct {
 type StringAssert struct {
 	Exactly     string
 	Equals      string
+	Matches     string
 	MustBeEmpty bool `yaml:"mustBeEmpty"`
 }
 


### PR DESCRIPTION
Test spec can use `$VAR_NAME`s for variable substitutions. The variable values are passed command line arguments `--vars VAR_NAME=value`, which can appear multiple times to define multiple variables.

Add `matches` in test expectation that accepts a regex.