### PR TITLE
Fix single file mounting for kubernetes

### DIFF
--- a/docgen/lib/render/enhanced.go
+++ b/docgen/lib/render/enhanced.go
@@ -492,15 +492,6 @@ func (t *RunInstruction_MountedVolume) KubernetesClaimName() string {
 	return t.KubernetesName()
 }
 
-func (t *RunInstruction_MountedVolume) Path() string {
-	path := t.RunInstruction_MountedVolume.Path
-	if t.GetSingleFile() != nil {
-		_, file := filepath.Split(t.GetSingleFile().HostFile())
-		return filepath.Join(path, file)
-	}
-	return path
-}
-
 func (t *RunInstruction_MountedVolume) GetEmptyPersistentVolume() *RunInstruction_MountedVolume_EmptyPersistentVolume {
 	p := t.RunInstruction_MountedVolume
 	if p.GetEmptyPersistentVolume() == nil {
@@ -541,6 +532,11 @@ func (t *RunInstruction_MountedVolume_SingleFile) HostFile() string {
 		return f
 	}
 	return "$(pwd)/" + f
+}
+
+func (t *RunInstruction_MountedVolume_SingleFile) HostFileBaseName() string {
+	_, file := filepath.Split(t.HostFile())
+	return file
 }
 
 func (t *RunInstruction_MountedVolume_SingleFile) ConfigMapName() string {

--- a/docgen/lib/render/templates/README.md.tmpl
+++ b/docgen/lib/render/templates/README.md.tmpl
@@ -37,7 +37,7 @@ docker run \
   {{- if .GetEmptyPersistentVolume}}
   -v {{.GetEmptyPersistentVolume.HostPath}}:{{.Path}} \
   {{- else if .GetSingleFile}}
-  -v {{.GetSingleFile.HostFile}}:{{.Path}} \
+  -v {{.GetSingleFile.HostFile}}:{{.Path}}/{{.GetSingleFile.HostFileBaseName}} \
   {{- end}}
   {{- end}}{{/* range .Volumes */}}
   -d \
@@ -59,7 +59,7 @@ docker run \
   {{- if .GetEmptyPersistentVolume}}
   -v {{.GetEmptyPersistentVolume.HostPath}}:{{.Path}} \
   {{- else if .GetSingleFile}}
-  -v {{.GetSingleFile.HostFile}}:{{.Path}} \
+  -v {{.GetSingleFile.HostFile}}:{{.Path}}/{{.GetSingleFile.HostFileBaseName}} \
   {{- end}}
   {{- end}}{{/* range .Volumes */}}
   {{- range .DependenciesWithLinkAlias}}
@@ -118,7 +118,7 @@ services:
       {{- if .GetEmptyPersistentVolume}}
       - {{.GetEmptyPersistentVolume.HostPath}}:{{.Path}}
       {{- else if .GetSingleFile}}
-      - {{.GetSingleFile.HostFile}}:{{.Path}}
+      - {{.GetSingleFile.HostFile}}:{{.Path}}/{{.GetSingleFile.HostFileBaseName}}
       {{- end}}
       {{- end}}{{/* range .Volumes */}}
     {{- end}}
@@ -149,7 +149,7 @@ services:
       {{- if .GetEmptyPersistentVolume}}
       - {{.GetEmptyPersistentVolume.HostPath}}:{{.Path}}
       {{- else if .GetSingleFile}}
-      - {{.GetSingleFile.HostFile}}:{{.Path}}
+      - {{.GetSingleFile.HostFile}}:{{.Path}}/{{.GetSingleFile.HostFileBaseName}}
       {{- end}}
       {{- end}}{{/* range .Volumes */}}
     {{- end}}


### PR DESCRIPTION
configmap should be mounted on a directory. Keys in the configmap
will become file names in that directory.