### PR TITLE
update publish job to write runtime.yaml manifest file

### DIFF
--- a/runtime_builders/builder_util.py
+++ b/runtime_builders/builder_util.py
@@ -56,6 +56,21 @@ def get_file_from_gcs(gcs_file, temp_file):
                       .format(e.output))
         return False
 
+
 def write_manifest_file(manifest):
-    manifest_contents = yaml.round_trip_dump(manifest, default_flow_style=False)
+    manifest_contents = yaml.round_trip_dump(manifest,
+                                             default_flow_style=False)
     write_to_gcs(MANIFEST_FILE, SCHEMA_LINE + manifest_contents)
+
+
+def load_manifest_file():
+    try:
+        _, tmp = tempfile.mkstemp(text=True)
+        command = ['gsutil', 'cp', MANIFEST_FILE, tmp]
+        subprocess.check_output(command, stderr=subprocess.STDOUT)
+        with open(tmp) as f:
+            return yaml.safe_load(f)
+    except subprocess.CalledProcessError:
+        logging.info('Manifest file not found in GCS: creating new one.')
+    finally:
+        os.remove(tmp)

--- a/runtime_builders/builder_util.py
+++ b/runtime_builders/builder_util.py
@@ -1,19 +1,37 @@
 #!/usr/bin/python
 
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
+from ruamel import yaml
 import subprocess
 import tempfile
-
-logging.getLogger().setLevel(logging.DEBUG)
 
 
 RUNTIME_BUCKET = 'runtime-builders'
 RUNTIME_BUCKET_PREFIX = 'gs://{0}/'.format(RUNTIME_BUCKET)
+MANIFEST_FILE = RUNTIME_BUCKET_PREFIX + 'runtimes.yaml'
+
+SCHEMA_VERSION = 1
+SCHEMA_LINE = 'schema_version: {0}\n'.format(SCHEMA_VERSION)
 
 
 def write_to_gcs(gcs_path, file_contents):
     try:
+        logging.info(gcs_path)
         fd, f_name = tempfile.mkstemp(text=True)
         os.write(fd, file_contents)
 
@@ -28,7 +46,7 @@ def write_to_gcs(gcs_path, file_contents):
         os.remove(f_name)
 
 
-def _get_file_from_gcs(gcs_file, temp_file):
+def get_file_from_gcs(gcs_file, temp_file):
     command = ['gsutil', 'cp', gcs_file, temp_file]
     try:
         subprocess.check_output(command, stderr=subprocess.STDOUT)
@@ -37,3 +55,7 @@ def _get_file_from_gcs(gcs_file, temp_file):
         logging.error('Error when retrieving file from GCS! {0}'
                       .format(e.output))
         return False
+
+def write_manifest_file(manifest):
+    manifest_contents = yaml.round_trip_dump(manifest, default_flow_style=False)
+    write_to_gcs(MANIFEST_FILE, SCHEMA_LINE + manifest_contents)

--- a/runtime_builders/data_integrity.py
+++ b/runtime_builders/data_integrity.py
@@ -69,7 +69,7 @@ def _verify_latest_files_match(project_name, config_latest):
     try:
         tmpdir = tempfile.mkdtemp()
         version_file = os.path.join(tmpdir, 'runtime.version')
-        builder_util._get_file_from_gcs(remote_version, version_file)
+        builder_util.get_file_from_gcs(remote_version, version_file)
 
         with open(version_file, 'r') as f:
             version_contents = f.read().strip('\n').strip(' ')
@@ -96,7 +96,7 @@ def _verify_latest_file_exists(latest_file_path):
         logging.info('Checking file {0}'.format(latest_file_path))
         tmpdir = tempfile.mkdtemp()
         latest_file = os.path.join(tmpdir, 'latest.yaml')
-        if not builder_util._get_file_from_gcs(latest_file_path, latest_file):
+        if not builder_util.get_file_from_gcs(latest_file_path, latest_file):
             logging.error('File {0} not found in GCS!'
                           .format(latest_file_path))
             return 1

--- a/runtime_builders/publish_builders.py
+++ b/runtime_builders/publish_builders.py
@@ -19,8 +19,6 @@ import json
 import logging
 import os
 import sys
-from ruamel import yaml
-from collections import OrderedDict
 
 import builder_util
 
@@ -34,7 +32,10 @@ def main():
                         required=True)
     args = parser.parse_args()
 
-    manifest = {}
+    manifest = builder_util.load_manifest_file()
+    if manifest is None:
+        manifest = {}
+    logging.info(manifest)
 
     try:
         for filename in os.listdir(args.directory):
@@ -42,26 +43,15 @@ def main():
             if filepath.endswith('.json'):
                 with open(filepath, 'r') as f:
                     config = json.load(f)
-                    project_name = config['project']
-                    latest = config['latest']
-                    prefix = builder_util.RUNTIME_BUCKET_PREFIX
-                    if not latest.startswith(prefix):
-                        logging.error('Please provide fully qualified '
-                                      'path to config file in GCS!')
-                        logging.error('Path should start with \'{0}\''
-                                      ''.format(prefix))
-                        sys.exit(1)
-                    parts = os.path.splitext(latest)
-                    if parts[1] != '.yaml':
-                        logging.error('Please provide yaml config file to '
-                                      'publish as latest!')
-                        sys.exit(1)
-                    full_prefix = prefix + project_name + '-'
-                    latest_file = parts[0][len(full_prefix):]
-                    latest_file_with_project = latest[len(prefix):]
-                    manifest[project_name] = \
-                        {'target': {'file': latest_file_with_project}}
-                    _write_version_file(project_name, latest_file)
+                prefix = builder_util.RUNTIME_BUCKET_PREFIX
+                latest = config['latest']
+                if not latest.startswith(prefix):
+                    logging.error('Please provide fully qualified path to '
+                                  'config file in GCS!')
+                    logging.error('Path should start with \'{0}\''
+                                  ''.format(prefix))
+                    sys.exit(1)
+                _format_and_write(config['project'], latest, prefix, manifest)
         builder_util.write_manifest_file(manifest)
     except ValueError as ve:
         logging.error('Error when parsing JSON! Check file formatting. \n{0}'
@@ -71,10 +61,37 @@ def main():
                       .format(ke))
 
 
+def _format_and_write(project_name, latest, prefix, manifest):
+    parts = os.path.splitext(latest)
+    if parts[1] != '.yaml':
+        logging.error('Please provide yaml config file to publish as latest!')
+        sys.exit(1)
+    try:
+        project_prefix = prefix + project_name + '-'
+        latest_file = parts[0][len(project_prefix):]
+        full_latest_file = latest[len(prefix):]
+        if project_name not in manifest.keys():
+            manifest[project_name] = {}
+            manifest[project_name]['target'] = {}
+            manifest[project_name]['target']['file'] = None
+            # TODO: add logic here for 'file' vs 'runtime' when
+            # we add support for versioning
+        m_project = manifest[project_name]
+        prev_builder = m_project['target']['file']
+        if prev_builder is not None and prev_builder != full_latest_file:
+            logging.warn('Overwriting old {0} builder: {1}'
+                         .format(project_name, prev_builder))
+        m_project['target']['file'] = full_latest_file
+        _write_version_file(project_name, latest_file)
+    except KeyError as ke:
+        logging.error('FATAL: Formatting issue encountered in manifest. '
+                      'Exiting. \n{0}'.format(ke))
+        sys.exit(1)
+
+
 def _write_version_file(project_name, latest_version):
     file_name = '{0}.version'.format(project_name)
     full_path = builder_util.RUNTIME_BUCKET_PREFIX + file_name
-
     builder_util.write_to_gcs(full_path, latest_version)
 
 

--- a/runtime_builders/publish_builders.py
+++ b/runtime_builders/publish_builders.py
@@ -32,9 +32,7 @@ def main():
                         required=True)
     args = parser.parse_args()
 
-    manifest = builder_util.load_manifest_file()
-    if manifest is None:
-        manifest = {}
+    manifest = builder_util.load_manifest_file() or {}
     logging.info(manifest)
 
     try:


### PR DESCRIPTION
This is a preliminary attempt at moving the runtime builder "pointers" to live inside of a single manifest file. This file will eventually contain all supported versions of a runtime and the corresponding builder for each; for now, this will just contain all of the `latest` versions in one file.

@markpell @dlorenc 