### PR TITLE
Skip writing the structure_test binary to /workspace.

### DIFF
--- a/structure_tests/run.sh
+++ b/structure_tests/run.sh
@@ -24,7 +24,7 @@ usage() {
 export DOCKER_API_VERSION="1.21"
 
 VERBOSE=0
-CMD_STRING="/workspace/structure_test"
+CMD_STRING="/test/structure_test"
 ENTRYPOINT="/bin/sh"
 
 while test $# -gt 0; do
@@ -65,8 +65,6 @@ while test $# -gt 0; do
 			;;
 	esac
 done
-
-cp /test/* /workspace/
 
 if [ $VERBOSE -eq 1 ]; then
 	CMD_STRING=$CMD_STRING" -test.v"


### PR DESCRIPTION
When we run the docker image, we're already providing all the available
volumes from the structure_test container. This includes /test which
already contains the structure_test binary.

This causes a conflict when you run this build step in parallel with itself. Both images try to write to the same location in /workspace (and the task can fail). An example of this is building 2 images in parallel, each with a structure test after completion.