### PR TITLE
account for prefix on images when templating

### DIFF
--- a/runtime_builders/template_builder.py
+++ b/runtime_builders/template_builder.py
@@ -99,7 +99,7 @@ def _resolve_tags(config_file):
                     m = re.search(IMAGE_REGEX, arg)
                     if m:
                         suffix = m.group()
-                        prefix = arg.replace(suffix, '')
+                        prefix = re.sub(suffix, '', arg)
                         args[i] = prefix + _resolve_tag(suffix)
 
             return yaml.round_trip_dump(config)

--- a/runtime_builders/template_builder.py
+++ b/runtime_builders/template_builder.py
@@ -64,7 +64,7 @@ def _resolve_and_publish(config_file, bucket):
         logging.info('Published Runtimes:')
         logging.info(gcs_paths)
     except ValueError as ve:
-        logging.error('Error when parsing JSON! Check file formatting. \n{0}'
+        logging.error('Error when parsing config! Check file formatting. \n{0}'
                       .format(ve))
     except KeyError as ke:
         logging.error('Config file is missing required field! \n{0}'
@@ -98,7 +98,9 @@ def _resolve_tags(config_file):
                     arg = args[i]
                     m = re.search(IMAGE_REGEX, arg)
                     if m:
-                        args[i] = _resolve_tag(arg)
+                        prefix = m.string[0:m.start()]
+                        suffix = m.string[m.start():m.end()]
+                        args[i] = prefix + _resolve_tag(suffix)
 
             return yaml.round_trip_dump(config)
         except yaml.YAMLError as e:

--- a/runtime_builders/template_builder.py
+++ b/runtime_builders/template_builder.py
@@ -98,8 +98,8 @@ def _resolve_tags(config_file):
                     arg = args[i]
                     m = re.search(IMAGE_REGEX, arg)
                     if m:
-                        prefix = m.string[0:m.start()]
-                        suffix = m.string[m.start():m.end()]
+                        suffix = m.group()
+                        prefix = arg.replace(suffix, '')
                         args[i] = prefix + _resolve_tag(suffix)
 
             return yaml.round_trip_dump(config)


### PR DESCRIPTION
This allows the job to template tags on strings like "1.1.1=gcr.io/google-appengine/aspnetcore:1.1.1"

@dlorenc @ivannaranjo