### PR TITLE
Deploy app with version to avoid collisions, and don't stop previous version

### DIFF
--- a/integration_tests/testsuite/deploy_app.py
+++ b/integration_tests/testsuite/deploy_app.py
@@ -14,12 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import logging
 import os
 import subprocess
-from retrying import retry
-
 import test_util
 
 
@@ -52,7 +49,7 @@ def deploy_app(image, appdir):
 
         subprocess.check_output(deploy_command)
 
-        return deployed_version, _retrieve_url(deployed_version)
+        return deployed_version
     except subprocess.CalledProcessError as cpe:
         logging.error('Error encountered when deploying application! %s',
                       cpe.output)
@@ -72,18 +69,3 @@ def stop_app(deployed_version):
     except subprocess.CalledProcessError as cpe:
         logging.error('Error encountered when deleting app version! %s',
                       cpe.output)
-
-
-@retry(wait_fixed=10000, stop_max_attempt_number=4)
-def _retrieve_url(version):
-    try:
-        # retrieve url of deployed app for test driver
-        url_command = ['gcloud', 'app', 'versions', 'describe',
-                       version, '--service',
-                       'default', '--format=json']
-        app_dict = json.loads(subprocess.check_output(url_command))
-        return app_dict.get('versionUrl')
-    except (subprocess.CalledProcessError, ValueError, KeyError):
-        logging.warn('Error encountered when retrieving app URL!')
-        return None
-    raise Exception('Unable to contact deployed application!')

--- a/integration_tests/testsuite/driver.py
+++ b/integration_tests/testsuite/driver.py
@@ -84,14 +84,14 @@ def _main():
             sys.exit(1)
 
         logging.debug('Deploying app!')
-        deploy_url = deploy_app.deploy_app(args.image, args.directory)
+        version, deploy_url = deploy_app.deploy_app(args.image, args.directory)
 
     application_url = args.url or deploy_url
 
     code = _test_app(application_url, args)
 
     if args.deploy:
-        deploy_app.stop_app()
+        deploy_app.stop_app(version)
 
     return code
 

--- a/integration_tests/testsuite/driver.py
+++ b/integration_tests/testsuite/driver.py
@@ -26,6 +26,7 @@ import test_logging_standard
 import test_logging_custom
 import test_monitoring
 import test_root
+import test_util
 
 
 def _main():
@@ -71,7 +72,6 @@ def _main():
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
-    deploy_url = ''
     application_url = ''
 
     if args.deploy:
@@ -84,9 +84,9 @@ def _main():
             sys.exit(1)
 
         logging.debug('Deploying app!')
-        version, deploy_url = deploy_app.deploy_app(args.image, args.directory)
+        version = deploy_app.deploy_app(args.image, args.directory)
 
-    application_url = args.url or deploy_url
+    application_url = args.url or test_util.retrieve_url_for_version(version)
 
     code = _test_app(application_url, args)
 

--- a/integration_tests/testsuite/driver.py
+++ b/integration_tests/testsuite/driver.py
@@ -38,11 +38,6 @@ def _main():
                         'image to build sample app on')
     parser.add_argument('--directory', '-d',
                         help='Root directory of sample app')
-    parser.add_argument('--no-deploy',
-                        action='store_false',
-                        dest='deploy',
-                        help='Flag to skip deployment of app ' +
-                        '(must provide app URL)')
     parser.add_argument('--skip-standard-logging-tests',
                         action='store_false',
                         dest='standard_logging',
@@ -74,7 +69,7 @@ def _main():
 
     application_url = ''
 
-    if args.deploy:
+    if not args.url:
         if args.image is None:
             logging.error('Please specify base image name.')
             sys.exit(1)
@@ -90,7 +85,7 @@ def _main():
 
     code = _test_app(application_url, args)
 
-    if args.deploy:
+    if not args.url:
         deploy_app.stop_app(version)
 
     return code

--- a/integration_tests/testsuite/test_util.py
+++ b/integration_tests/testsuite/test_util.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import binascii
+import datetime
 import json
 import logging
 import os
@@ -140,3 +141,7 @@ def _project_id():
 
 def get_default_url():
     return 'https://{0}.appspot.com'.format(_project_id())
+
+
+def generate_version():
+    return datetime.datetime.now().strftime('%Y%m%d%H%m%S')

--- a/integration_tests/testsuite/test_util.py
+++ b/integration_tests/testsuite/test_util.py
@@ -24,6 +24,7 @@ import requests
 from retrying import retry
 import string
 import subprocess
+import sys
 
 requests.packages.urllib3.disable_warnings()
 
@@ -152,7 +153,7 @@ def retrieve_url_for_version(version):
                        'default', '--format=json']
         app_dict = json.loads(subprocess.check_output(url_command))
         return app_dict.get('versionUrl')
-    except (subprocess.CalledProcessError, ValueError, KeyError):
-        logging.warn('Error encountered when retrieving app URL!')
-        return None
+    except (subprocess.CalledProcessError, ValueError, KeyError) as e:
+        logging.warn('Error encountered when retrieving app URL! %s', e)
+        sys.exit(1)
     raise Exception('Unable to contact deployed application!')

--- a/integration_tests/testsuite/test_util.py
+++ b/integration_tests/testsuite/test_util.py
@@ -45,8 +45,6 @@ METRIC_TIMEOUT = 60  # seconds
 # subset of levels found at
 # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
 SEVERITIES = [
-    'DEBUG',
-    'INFO',
     'WARNING',
     'ERROR',
     'CRITICAL'
@@ -139,9 +137,6 @@ def _project_id():
         logging.error(e)
 
 
-def get_default_url():
-    return 'https://{0}.appspot.com'.format(_project_id())
-
-
 def generate_version():
-    return datetime.datetime.now().strftime('%Y%m%d%H%m%S')
+    return 'integration-{0}'.format(
+        datetime.datetime.now().strftime('%Y%m%d%H%m%S'))


### PR DESCRIPTION
This will allow us to run multiple integration test runs simultaneously.

@sharifelgamal @dlorenc 