### PR TITLE
Prefer concatenate over os.path.join, and str.replace over substring

### DIFF
--- a/runtime_builders/publish_builders.py
+++ b/runtime_builders/publish_builders.py
@@ -63,9 +63,8 @@ def _publish_latest(builder_dir):
         project_name = config['project']
 
         parts = os.path.splitext(latest)
-        project_prefix = os.path.join(builder_util.RUNTIME_BUCKET_PREFIX,
-                                      project_name, '-')
-        latest_file = parts[0][len(project_prefix):]
+        prefix = builder_util.RUNTIME_BUCKET_PREFIX + project_name + '-'
+        latest_file = parts[0].replace(prefix, '')
         file_name = '{0}.version'.format(project_name)
         full_path = builder_util.RUNTIME_BUCKET_PREFIX + file_name
         builder_util.write_to_gcs(full_path, latest_file)


### PR DESCRIPTION
Using `os.path.join` actually produces erroneous results here, as it puts an extra `/` between the project name and the hyphen separator. SInce this path is only used to retrieve artifacts from GCS (and never anything on the actual host machine), we don't need to care about being platform agnostic, so concatenation should work fine.

Additionally, using substring to retrieve the builder name was hiding this error, so switching to using `str.replace()` as it's cleaner anyway.

@dlorenc @sharifelgamal 