### PR TITLE
Copy files from the templates directory

### DIFF
--- a/versioning/scripts/dockerfiles/main.go
+++ b/versioning/scripts/dockerfiles/main.go
@@ -10,6 +10,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"text/template"
 
 	"github.com/GoogleCloudPlatform/runtimes-common/versioning/versions"
@@ -23,13 +25,55 @@ func renderDockerfile(version versions.Version, tmpl template.Template) []byte {
 
 func writeDockerfile(version versions.Version, data []byte) {
 	path := filepath.Join(version.Dir, "Dockerfile")
+	// Delete first to make sure file is created with the right mode.
+	deleteIfFileExists(path)
 	err := ioutil.WriteFile(path, data, 0644)
 	check(err)
 }
 
-func verifyDockerfiles(spec versions.Spec, tmpl template.Template) {
+func findFilesToCopy(templateDir string, callback func(path string, fileInfo os.FileInfo)) {
+	filepath.Walk(templateDir, func(path string, info os.FileInfo, err error) error {
+		check(err)
+		if strings.HasSuffix(info.Name(), ".template") || info.IsDir() {
+			return nil
+		}
+		path, err = filepath.Rel(templateDir, path)
+		check(err)
+		callback(path, info)
+		return nil
+	})
+}
+
+func copyFiles(version versions.Version, templateDir string) {
+	findFilesToCopy(templateDir, func(path string, fileInfo os.FileInfo) {
+		data, err := ioutil.ReadFile(filepath.Join(templateDir, path))
+		check(err)
+
+		target := filepath.Join(version.Dir, path)
+		// Delete first to make sure file is created with the right mode.
+		deleteIfFileExists(target)
+		err = ioutil.WriteFile(target, data, fileInfo.Mode())
+		check(err)
+	})
+}
+
+func deleteIfFileExists(path string) {
+	if fileInfo, err := os.Stat(path); err != nil {
+		if !os.IsNotExist(err) {
+			log.Fatalf("File %s exists but cannot be stat'ed", path)
+		}
+	} else {
+		if fileInfo.IsDir() {
+			log.Fatalf("%s is unexpectedly a directory", path)
+		}
+		err = os.Remove(path)
+		check(err)
+	}
+}
+
+func verifyDockerfiles(spec versions.Spec, tmpl template.Template) (failureCount int) {
 	foundDockerfile := make(map[string]bool)
-	failureCount := 0
+	failureCount = 0
 	warningCount := 0
 
 	for _, version := range spec.Versions {
@@ -67,7 +111,57 @@ func verifyDockerfiles(spec versions.Spec, tmpl template.Template) {
 		log.Print("Dockerfile verification completed: FAILED")
 	}
 
-	os.Exit(failureCount)
+	return
+}
+
+func verifyCopiedFiles(spec versions.Spec, templateDir string) (failureCount int) {
+	failureCount = 0
+	for _, version := range spec.Versions {
+		findFilesToCopy(templateDir, func(path string, sourceFileInfo os.FileInfo) {
+			failureCount++
+
+			source := filepath.Join(templateDir, path)
+			target := filepath.Join(version.Dir, path)
+			targetFileInfo, err := os.Stat(target)
+			if err != nil {
+				log.Printf("%s is expected but cannot be stat'ed", target)
+				return
+			}
+
+			// Check mode for owner only.
+			sourcePerm := os.FileMode(sourceFileInfo.Mode().Perm() & 0700)
+			targetPerm := os.FileMode(targetFileInfo.Mode().Perm() & 0700)
+			if sourcePerm != targetPerm {
+				log.Printf("%s has wrong file mode %v, expected %v", target, targetPerm, sourcePerm)
+				return
+			}
+
+			expected, err := ioutil.ReadFile(source)
+			check(err)
+			actual, err := ioutil.ReadFile(filepath.Join(version.Dir, path))
+			if err != nil {
+				log.Printf("%s is expected but cannot be read", target)
+				return
+			}
+
+			if !reflect.DeepEqual(expected, actual) {
+				log.Printf("%s content is different from its template", target)
+				return
+			}
+
+			log.Printf("%s: OK", target)
+
+			failureCount--
+		})
+	}
+
+	if failureCount == 0 {
+		log.Print("Copied files verification completed: PASSED")
+	} else {
+		log.Print("Copied files verification completed: FAILED")
+	}
+
+	return
 }
 
 func check(e error) {
@@ -77,7 +171,7 @@ func check(e error) {
 }
 
 func main() {
-	templateDirPtr := flag.String("template_dir", "templates", "Path to directory containing Dockerfile.template")
+	templateDirPtr := flag.String("template_dir", "templates", "Path to directory containing Dockerfile.template and any other files to copy over")
 	verifyPtr := flag.Bool("verify_only", false, "Verify dockerfiles")
 	flag.Parse()
 
@@ -95,11 +189,14 @@ func main() {
 	check(err)
 
 	if *verifyPtr {
-		verifyDockerfiles(spec, *tmpl)
+		failureCount := verifyDockerfiles(spec, *tmpl)
+		failureCount += verifyCopiedFiles(spec, *templateDirPtr)
+		os.Exit(failureCount)
 	} else {
 		for _, version := range spec.Versions {
 			data := renderDockerfile(version, *tmpl)
 			writeDockerfile(version, data)
+			copyFiles(version, *templateDirPtr)
 		}
 	}
 }


### PR DESCRIPTION
Shared files across versions can be put in the templates
directory and they will be distributed to individual version
directories. In the future, we can also support generic .template
files, which are currently not copied; in that case, Dockerfile
will just be a special case.