### PR TITLE
Release notes generation script

### DIFF
--- a/release_notes/release_notes.py
+++ b/release_notes/release_notes.py
@@ -10,126 +10,150 @@ from requests.auth import HTTPBasicAuth
 
 requests.packages.urllib3.disable_warnings()
 
-# OWNER = 'GoogleCloudPlatform'
-OWNER = 'nkubala'
-REPO = 'runtimes-common'
-USER = 'XXX'
-PW = 'XXX'
 
+class ReleaseNotes():
 
-API_BASE = 'https://api.github.com'
-REPO_BASE = '{api_base}/repos/{owner}/{repo}'
-REPO_URL = REPO_BASE.format(api_base=API_BASE, owner=OWNER, repo=REPO)
+    def __init__(self, args):
+        self.owner = args.owner
+        self.repo = args.repo
+        self.old_image = args.old
+        self.new_image = args.new
 
-COMMIT_URL = REPO_URL + '/commits'
-COMMITISH_URL = COMMIT_URL + '/master'
+        API_BASE = 'https://api.github.com'
+        REPO_BASE = '{api_base}/repos/{owner}/{repo}'
+        self.REPO_URL = REPO_BASE.format(api_base=API_BASE,
+                                         owner=args.owner,
+                                         repo=args.repo)
 
-SHA_URL = COMMIT_URL + '/master'
-RELEASE_URL = REPO_URL + '/releases'
-LATEST_RELEASE_URL = RELEASE_URL + '/latest'
+        self.COMMIT_URL = self.REPO_URL + '/commits'
+        self.COMMITISH_URL = self.COMMIT_URL + '/master'
 
-COMMITISH_HEADER = {'Accept': 'application/vnd.github.VERSION.sha'}
+        self.SHA_URL = self.COMMIT_URL + '/master'
+        self.RELEASE_URL = self.REPO_URL + '/releases'
+        self.LATEST_RELEASE_URL = self.RELEASE_URL + '/latest'
 
-sess = requests.Session()
-sess.auth = HTTPBasicAuth(USER, PW)
+        self.COMMITISH_HEADER = {'Accept':
+                                 'application/vnd.github.VERSION.sha'}
+
+        self.sess = requests.Session()
+        self.sess.auth = HTTPBasicAuth(args.user, args.password)
+
+        # retrieve latest release for use later on
+        latest_release = self.sess.get(self.LATEST_RELEASE_URL).content
+        self.latest_release = json.loads(latest_release)
+
+    def diff_images(self):
+        '''
+        most likely use the image differ tool created by the interns here
+        we could potentially remove the drydock querying in favor of using this
+        depending on what kind of language level diffing the differ tools has
+        '''
+        return ''
+
+    def retrieve_commit_messages(self):
+        prev_sha = self.latest_release.get('target_commitish')
+
+        # get timestamp of last release,then retrieve all commits since
+        commit = json.loads(self.sess.get(self.COMMIT_URL +
+                                          '/{0}'.format(prev_sha)).content)
+        prev_timestamp = commit.get('commit').get('author').get('date')
+        params = {'since': prev_timestamp}
+        raw_commits = json.loads(self.sess.get(self.COMMIT_URL,
+                                               params=params).content)
+
+        # TODO: possibly parse each commit and retrieve relevant information?
+        return '\n'.join(['* ' + str(c.get('commit').get('message'))
+                          for c in raw_commits])
+
+    def run_package_analysis(self):
+        '''
+        use drydock to retrieve package analysis information for each image,
+        then diff this info to see differences in installed packages
+
+        unclear if we want to do language specific diffing here: this may just
+        come from information provided manually by the maintainers
+        '''
+        return ''
+
+    def create_release(self, release_notes):
+        release_payload = self._generate_release_payload(release_notes)
+        logging.debug('Posting to url {0}'.format(self.RELEASE_URL))
+        response = self.sess.post(self.RELEASE_URL,
+                                  data=json.dumps(release_payload))
+        if response.status_code < 200 or response.status_code > 299:
+            logging.error('Error when creating release (code {0})'
+                          .format(response.status_code))
+            logging.error(response.text)
+            sys.exit(1)
+        logging.info('Drafted release created. View at: {0}'
+                     .format(json.loads(response.text).get('html_url')))
+
+    def _generate_release_payload(self, release_notes):
+        try:
+            prev_tag = self.latest_release['tag_name'].replace('v', '')
+            tag = 'v' + semver.bump_minor(prev_tag)
+
+            commitish = self.sess.get(self.COMMITISH_URL,
+                                      headers=self.COMMITISH_HEADER).content
+        except (TypeError, KeyError, ValueError) as e:
+            logging.error('Error encountered when retrieving '
+                          'latest version! %s', e)
+            sys.exit(1)
+
+        return {
+            "tag_name": tag,
+            "target_commitish": commitish,
+            "name": tag,
+            "body": release_notes,
+            "draft": True
+        }
 
 
 def main():
     logging.getLogger().setLevel(logging.INFO)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--old', '-o', help='old image')
-    parser.add_argument('--new', '-n', help='new image')
+    parser.add_argument('--old', '-o', help='old image', required=True)
+    parser.add_argument('--new', '-n', help='new image', required=True)
+    parser.add_argument('--user',
+                        help='Github robot username',
+                        required=True)
+    parser.add_argument('--password',
+                        help='Github robot password',
+                        required=True)
+    parser.add_argument('--owner',
+                        help='Github project owner',
+                        required=True)
+    parser.add_argument('--repo', '-r',
+                        help='target Github repository to publish release',
+                        required=True)
     parser.add_argument('--verbose', '-v', action='store_true')
     args = parser.parse_args()
-    # image_diff = _diff_images(args.old, args.new)
-    commits = _retrieve_commit_messages()
-    # package_diff = _run_package_analysis(args.old, args.new)
 
-    # TODO: combine retrieved info into real release notes 
-    full_notes = "here are some notes"
+    release_notes = ReleaseNotes(args)
 
-    # _create_release(full_notes)
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
 
+    image_diff = release_notes.diff_images()
+    commits = release_notes.retrieve_commit_messages()
+    package_diff = release_notes.run_package_analysis()
 
-def _diff_images(old_image, new_image):
-    '''
-    most likely use the image differ tool created by the interns here
-    we could potentially remove the drydock querying in favor of using this
-    depending on what kind of language level diffing the differ tools has
-    '''
-    return 0
+    full_notes = '''**Notes:**
 
+**Image Diff Information**:
+{image_diff}
 
-def _retrieve_commit_messages():
-    # TODO: only make this call once and cache somewhere
-    latest_release = sess.get(LATEST_RELEASE_URL).content
-    latest_release = json.loads(latest_release)
-    prev_sha = latest_release.get('target_commitish')
-    logging.info(prev_sha)
+**Package Diff Information**:
+{package_diff}
 
-    prev_commit = json.loads(sess.get(COMMIT_URL + '/{0}'.format(prev_sha)).content)
-    prev_timestamp = prev_commit.get('commit').get('author').get('date')
-    commits = sess.get(COMMIT_URL, params={'since':prev_timestamp}).content
-    logging.info(json.dumps(json.loads(commits), indent=4))
+**Commits since last release**:
+{commits}
+'''.format(image_diff=image_diff,
+           package_diff=package_diff,
+           commits=commits)
 
-    '''
-    1. use releases API to retrieve commit hash from last release
-    2. retrieve all commit hashes between then and HEAD
-    3. loop through commits, retrieve messages
-    4. (maybe) parse through each commit and retrieve relevant information?
-    '''
-    return []
-
-
-def _run_package_analysis(old_image, new_image):
-    '''
-    here we want to use drydock to retrieve package analysis information for
-    each image, then diff this info to see differences in installed packages
-
-    unclear if we want to do language specific diffing here: this may just come
-    from information provided manually by the maintainers
-    '''
-    return 0
-
-
-def _create_release(release_notes):
-    release_payload = _generate_release_payload(release_notes)
-    logging.info('Posting to url {0}'.format(RELEASE_URL))
-    response = sess.post(RELEASE_URL, data=json.dumps(release_payload))
-    # response = requests.get(RELEASE_URL)
-    if response.status_code < 200 or response.status_code > 299:
-        logging.error('Error when creating release (code {0})'
-                      .format(response.status_code))
-        logging.error(response.text)
-        sys.exit(1)
-    logging.info(json.dumps(json.loads(response.text), indent=4))
-    return 0
-
-
-def _generate_release_payload(release_notes):
-    try:
-        logging.debug('getting latest release from url: %s', LATEST_RELEASE_URL)
-        latest_release = sess.get(LATEST_RELEASE_URL).content
-        latest_release = json.loads(latest_release)
-        logging.debug(latest_release)
-
-        prev_tag = latest_release['tag_name'].replace('v', '')
-        tag = 'v' + semver.bump_minor(prev_tag)
-
-        commitish = sess.get(COMMITISH_URL, headers=COMMITISH_HEADER).content
-    except (TypeError, KeyError, ValueError) as e:
-        logging.error('Error encountered when retrieving latest version! %s', e)
-        sys.exit(1)
-
-
-    return {
-        "tag_name": tag,
-        "target_commitish": commitish,
-        "name": tag,
-        "body": release_notes,
-        "draft": True
-    }
+    release_notes.create_release(full_notes)
 
 
 if __name__ == '__main__':

--- a/release_notes/release_notes.py
+++ b/release_notes/release_notes.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python
+
+import argparse
+import json
+import logging
+import semver
+import sys
+import requests
+from requests.auth import HTTPBasicAuth
+
+requests.packages.urllib3.disable_warnings()
+
+API_BASE = 'https://api.github.com'
+RELEASE_BASE = '{api_base}/repos/{owner}/{repo}/releases'
+# OWNER = 'GoogleCloudPlatform'
+OWNER = 'nkubala'
+REPO = 'runtimes-common'
+USER = 'XXX'
+PW = 'XXX'
+
+RELEASE_URL = RELEASE_BASE.format(api_base=API_BASE, owner=OWNER, repo=REPO)
+LATEST_RELEASE_URL = RELEASE_URL + '/latest'
+
+
+def main():
+    logging.getLogger().setLevel(logging.INFO)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--old', '-o', help='old image')
+    parser.add_argument('--new', '-n', help='new image')
+    parser.add_argument('--verbose', '-v', action='store_true')
+    args = parser.parse_args()
+    # image_diff = _diff_images(args.old, args.new)
+    commits = _retrieve_commit_messages()
+    # package_diff = _run_package_analysis(args.old, args.new)
+
+    # TODO: combine retrieved info into real release notes 
+    full_notes = "here are some notes"
+
+    _create_release(full_notes)
+
+
+def _diff_images(old_image, new_image):
+    '''
+    most likely use the image differ tool created by the interns here
+    we could potentially remove the drydock querying in favor of using this
+    depending on what kind of language level diffing the differ tools has
+    '''
+    return 0
+
+
+def _retrieve_commit_messages():
+    '''
+    1. use releases API to retrieve commit hash from last release
+    2. retrieve all commit hashes between then and HEAD
+    3. loop through commits, retrieve messages
+    4. (maybe) parse through each commit and retrieve relevant information?
+    '''
+    return []
+
+
+def _run_package_analysis(old_image, new_image):
+    '''
+    here we want to use drydock to retrieve package analysis information for
+    each image, then diff this info to see differences in installed packages
+
+    unclear if we want to do language specific diffing here: this may just come
+    from information provided manually by the maintainers
+    '''
+    return 0
+
+
+def _create_release(release_notes):
+    release_payload = _generate_release_payload(release_notes)
+    logging.info('Posting to url {0}'.format(RELEASE_URL))
+    response = requests.post(RELEASE_URL, data=json.dumps(release_payload),
+                             auth=HTTPBasicAuth(USER, PW))
+    # response = requests.get(RELEASE_URL)
+    if response.status_code < 200 or response.status_code > 299:
+        logging.error('Error when creating release (code {0})'
+                      .format(response.status_code))
+        logging.error(response.text)
+        sys.exit(1)
+    logging.info(json.dumps(json.loads(response.text), indent=4))
+    return 0
+
+
+def _generate_release_payload(release_notes):
+    try:
+        logging.debug('getting latest release from url: %s', LATEST_RELEASE_URL)
+        latest_release = requests.get(LATEST_RELEASE_URL,
+                                      auth=HTTPBasicAuth(USER, PW)).content
+        latest_release = json.loads(latest_release)
+        logging.debug(latest_release)
+
+        prev_tag = latest_release['tag_name'].replace('v', '')
+        tag = 'v' + semver.bump_minor(prev_tag)
+    except (TypeError | ValueError) as e:
+        logging.error('Error encountered when retrieving latest version! %s', e)
+        sys.exit(1)
+
+    return {
+        "tag_name": tag,
+        "target_commitish": "master",
+        "name": tag,
+        "body": release_notes,
+        "draft": True
+    }
+
+
+if __name__ == '__main__':
+    main()

--- a/release_notes/release_notes.py
+++ b/release_notes/release_notes.py
@@ -48,6 +48,7 @@ class ReleaseNotes():
         we could potentially remove the drydock querying in favor of using this
         depending on what kind of language level diffing the differ tools has
         '''
+        # TODO: implement
         return ''
 
     def retrieve_commit_messages(self):
@@ -73,6 +74,7 @@ class ReleaseNotes():
         unclear if we want to do language specific diffing here: this may just
         come from information provided manually by the maintainers
         '''
+        # TODO: implement
         return ''
 
     def create_release(self, release_notes):
@@ -90,6 +92,7 @@ class ReleaseNotes():
 
     def _generate_release_payload(self, release_notes):
         try:
+            # TODO: support non-semver versions and tags
             prev_tag = self.latest_release['tag_name'].replace('v', '')
             tag = 'v' + semver.bump_minor(prev_tag)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-pip
-pep8
-flake8
-mock
+flake8==3.0.4
+mock==2.0.0
+pip==9.0.1
+pep8==1.7.0
+retrying==1.3.3
+requests==2.12.4
+semver==2.7.7


### PR DESCRIPTION
This adds a tool to create draft of a github release for new image releases. The tool is still a work in progress; this PR adds the first version of the tool which has basic release creation functionality through the Github API, as well as filling the release with some basic commit information. Given a Github owner/repository pair, the tool will retrieve all commits added since the last release, and add them to the release notes.

Eventually, the tool will also perform some diffing on the old/new image, both at a OS level and also (potentially) at a language level. The tool also leaves space for maintainers to add optional notes in the release manually.

The tool creates a draft of the release, which must be published manually by a maintainer. It defaults to bumping the minor version of the previous release.

@dlorenc @sharifelgamal 