### PR TITLE
don't promote integration test version when deploying

### DIFF
--- a/integration_tests/testsuite/deploy_app.py
+++ b/integration_tests/testsuite/deploy_app.py
@@ -51,7 +51,7 @@ def deploy_app(image, appdir):
         deployed_version = test_util.generate_version()
 
         # TODO: once sdk driver is published, use it here
-        deploy_command = ['gcloud', 'app', 'deploy',
+        deploy_command = ['gcloud', 'app', 'deploy', '--no-promote'
                           '--version', deployed_version, '-q']
 
         subprocess.check_output(deploy_command)


### PR DESCRIPTION
don't direct traffic at this version, since we're deleting it as soon as we're done anyway.

This requires that a placeholder version has already been deployed to the default service, so I'll make sure and have that deployed before running the tests.

@dlorenc 