### PR TITLE
Add support for integration testing runtime builder image

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,7 +1,7 @@
 Integration Testing Framework
 =============
 
-This code builds an image which serves as a framework to run basic integration tests for a language runtime image. It relies on the existence of a sample application which fulfills a spec (detailed below), that will be built and deployed on top of the newly built runtime image. These tests are intended to be run as part of a post-push verification step in a continuous deployment system. The test driver can be run directly via any build host, or as a build step in a [Google Cloud Container Build](https://cloud.google.com/container-builder/docs/overview)).
+This code builds an image which serves as a framework to run basic integration tests for a language runtime. It relies on the existence of a sample application which fulfills a spec (detailed below), that will be built and deployed on top of either a newly built runtime image, or built on the language runtime through the gcloud builder flow, using a newly built runtime builder image. These tests are intended to be run as part of a post-push verification step in a continuous deployment system. The test driver can be run directly via any build host, or as a build step in a [Google Cloud Container Build](https://cloud.google.com/container-builder/docs/overview)).
 
 To run these tests through a cloudbuild, add the following build step to the **end** of your build config (cloudbuild.yaml or cloudbuild.json):
 
@@ -19,7 +19,21 @@ The sample application directory should contain the application fulfilling the i
 * a templated `Dockerfile.in`, with the first line being
 	` FROM ${STAGING_IMAGE} `
 
+	**OR**
+
+* a templated `test.yaml.in`, containing a step for the runtime builder that looks like:
+
+	- name: ${STAGING_BUILDER_IMAGE} 
+	- args: [] (these are optional)
+
+	**AND**
+
 * an `app.yaml` config
+
+If the tests are being deployed using a staging runtime builder image, the following gcloud config values **must be set, or else the build will fail**:
+
+* `app/use_runtime_builders` set to `True` (tells the gcloud installation to use the runtime builder flow)
+* `app/runtime_builders_root` set to *the location of the runtime manifest* (tells gcloud where to look for your local runtime builder, which in turn contains the staging runtime builder image).
 
 Alternatively, the application can be manually deployed *before* running the tests; in this scenario, the '--no-deploy' flag can be passed to the build step to opt out of deploying, in tandem with the URL at which the deployed application can be accessed:
 

--- a/integration_tests/testsuite/deploy_app.py
+++ b/integration_tests/testsuite/deploy_app.py
@@ -34,8 +34,6 @@ def _set_base_image(image):
         with open('Dockerfile', 'w') as fout:
             for line in fin:
                 fout.write(line.replace('${STAGING_IMAGE}', image))
-        fout.close()
-    fin.close()
 
 
 def _set_builder_image(builder):
@@ -43,8 +41,6 @@ def _set_builder_image(builder):
         with open('test.yaml', 'w') as fout:
             for line in fin:
                 fout.write(line.replace('${STAGING_BUILDER_IMAGE}', builder))
-        fout.close()
-    fin.close()
 
 
 def deploy_app(base_image, builder_image, appdir, yaml):

--- a/integration_tests/testsuite/deploy_app.py
+++ b/integration_tests/testsuite/deploy_app.py
@@ -28,7 +28,7 @@ def _cleanup(appdir):
         pass
 
 
-def _set_app_image(image):
+def _set_base_image(image):
     # substitute vars in Dockerfile (equivalent of envsubst)
     with open('Dockerfile.in', 'r') as fin:
         with open('Dockerfile', 'w') as fout:
@@ -38,21 +38,39 @@ def _set_app_image(image):
     fin.close()
 
 
-def deploy_app(image, appdir):
+def _set_builder_image(builder):
+    with open('test.yaml.in', 'r') as fin:
+        with open('test.yaml', 'w') as fout:
+            for line in fin:
+                fout.write(line.replace('${STAGING_BUILDER_IMAGE}', builder))
+        fout.close()
+    fin.close()
+
+
+def deploy_app(base_image, builder_image, appdir, yaml):
     try:
+        if yaml:
+            # convert yaml to absolute path before changing directory
+            yaml = os.path.abspath(yaml)
+
         # change to app directory (and remember original directory)
         owd = os.getcwd()
         os.chdir(appdir)
 
-        # fills in image field in templated Dockerfile if image is specified
-        if image:
-            _set_app_image(image)
+        # fills in image field in templated Dockerfile and/or builder yaml
+        if base_image:
+            _set_base_image(base_image)
+        if builder_image:
+            _set_builder_image(builder_image)
 
         deployed_version = test_util.generate_version()
 
         # TODO: once sdk driver is published, use it here
-        deploy_command = ['gcloud', 'app', 'deploy', '--no-promote'
+        deploy_command = ['gcloud', 'app', 'deploy', '--no-promote',
                           '--version', deployed_version, '-q']
+        if yaml:
+            logging.info(yaml)
+            deploy_command.append(yaml)
 
         subprocess.check_output(deploy_command)
 
@@ -68,7 +86,7 @@ def deploy_app(image, appdir):
 
 
 def deploy_app_without_image(appdir):
-    return deploy_app(None, appdir)
+    return deploy_app(None, None, appdir, None)
 
 
 def stop_app(deployed_version):

--- a/integration_tests/testsuite/driver.py
+++ b/integration_tests/testsuite/driver.py
@@ -62,6 +62,11 @@ def _main():
                         help='URL where deployed app is ' +
                         'exposed (if applicable)')
     parser.add_argument('--verbose', '-v', action='store_true')
+    parser.add_argument('--builder', '-b',
+                        help='builder file to template')
+    parser.add_argument('--yaml', '-y',
+                        help='optional path to app.yaml file',
+                        required=False)
     args = parser.parse_args()
 
     if args.verbose:
@@ -70,8 +75,8 @@ def _main():
     application_url = ''
 
     if not args.url:
-        if args.image is None:
-            logging.error('Please specify base image name.')
+        if args.image is None and args.builder is None:
+            logging.error('Please specify base image or builder image name.')
             sys.exit(1)
 
         if args.directory is None:
@@ -79,7 +84,8 @@ def _main():
             sys.exit(1)
 
         logging.debug('Deploying app!')
-        version = deploy_app.deploy_app(args.image, args.directory)
+        version = deploy_app.deploy_app(args.image, args.builder,
+                                        args.directory, args.yaml)
 
     application_url = args.url or test_util.retrieve_url_for_version(version)
 


### PR DESCRIPTION
This adds support for integration testing the runtime builder images, as part of the gcloud app deploy flow. The sample application will be provided with a templated builder `test.yaml.in` file (as opposed to a templated `Dockerfile.in`), which will have the staging builder image inserted into it, and used as the runtime builder via setting a gcloud config var.

Some runtimes (such as golang) do not even have a base runtime image to integration test, so this is a necessary feature for e2e testing the silver languages.

@dlorenc 