### PR TITLE
Add prefix to log entries for easy search

### DIFF
--- a/integration_tests/testsuite/test_logging_custom.py
+++ b/integration_tests/testsuite/test_logging_custom.py
@@ -55,7 +55,9 @@ class TestCustomLogging(unittest.TestCase):
     def _read_log(self, client, log_name, token, level):
         project_id = test_util.project_id()
         FILTER = 'logName = projects/{0}/logs/' \
-                 '{1}'.format(project_id, log_name)
+                 '{1} AND textPayload:{2}'.format(project_id,
+                                                  log_name,
+                                                  test_util.LOGGING_PREFIX)
         for entry in client.list_entries(filter_=FILTER):
             logging.debug(entry.payload)
             if token in entry.payload:

--- a/integration_tests/testsuite/test_logging_standard.py
+++ b/integration_tests/testsuite/test_logging_standard.py
@@ -56,7 +56,9 @@ class TestStandardLogging(unittest.TestCase):
     def _read_log(self, client, log_name, token, level):
         project_id = test_util.project_id()
         FILTER = 'logName = projects/{0}/logs/' \
-                 '{1}'.format(project_id, log_name)
+                 '{1} AND textPayload:"{2}"'.format(project_id,
+                                                    log_name,
+                                                    test_util.LOGGING_PREFIX)
         for entry in client.list_entries(filter_=FILTER):
             # since the logs we're examining are for the deployed flex app,
             # we can safely log from the test driver without contaminating

--- a/integration_tests/testsuite/test_util.py
+++ b/integration_tests/testsuite/test_util.py
@@ -30,6 +30,8 @@ requests.packages.urllib3.disable_warnings()
 
 LOGNAME_LENGTH = 16
 
+LOGGING_PREFIX = 'GCP_INTEGRATION_TEST_'
+
 DEFAULT_TIMEOUT = 30  # seconds
 
 ROOT_ENDPOINT = '/'
@@ -72,7 +74,7 @@ def generate_logging_payloads():
     for s in SEVERITIES:
         payloads.append({
             'log_name': _generate_name(),
-            'token': _generate_hex_token(),
+            'token': LOGGING_PREFIX + _generate_hex_token(),
             'level': s
             })
     return payloads


### PR DESCRIPTION
This is a cleaner solution than blacklisting out health check entries, transport errors and other polluting messages. Should fix logging failures in the integration tests.

@dlorenc 