### PR TITLE
Allow empty response for custom tests from sample app

### DIFF
--- a/integration_tests/testsuite/test_custom.py
+++ b/integration_tests/testsuite/test_custom.py
@@ -36,19 +36,22 @@ class TestCustom(unittest.TestCase):
                           'Cannot connect to sample application!')
 
         test_num = 0
-        for test_info in json.loads(output):
-            test_num += 1
-            name = test_info.get('name', 'test_{0}'.format(test_num))
-            path = test_info.get('path')
-            if path is None:
-                logging.warn('Test \'{0}\' has no path specified! '
-                             'Skipping...'.format(name))
-                continue
+        if not output:
+            logging.debug('No custom tests specified.')
+        else:
+            for test_info in json.loads(output):
+                test_num += 1
+                name = test_info.get('name', 'test_{0}'.format(test_num))
+                path = test_info.get('path')
+                if path is None:
+                    logging.warn('Test \'%s\' has no path specified! '
+                                 'Skipping...', name)
+                    continue
 
-            timeout = test_info.get('timeout', 500)
+                timeout = test_info.get('timeout', 500)
 
-            test_endpoint = urlparse.urljoin(self._base_url, path)
-            logging.info('Running custom test: {0}'.format(name))
-            response, code = test_util.get(test_endpoint, timeout=timeout)
+                test_endpoint = urlparse.urljoin(self._base_url, path)
+                logging.info('Running custom test: %s', name)
+                response, _ = test_util.get(test_endpoint, timeout=timeout)
 
-            logging.debug(response)
+                logging.debug(response)

--- a/integration_tests/testsuite/test_monitoring.py
+++ b/integration_tests/testsuite/test_monitoring.py
@@ -43,7 +43,7 @@ class TestMonitoring(unittest.TestCase):
                                           payload.get('token'), client),
                         'Token not found in Stackdriver monitoring!')
 
-    @retry(wait_fixed=6000, stop_max_attempt_number=10)
+    @retry(wait_fixed=8000, stop_max_attempt_number=10)
     def _read_metric(self, name, target, client):
         query = client.query(name, minutes=2)
         if self._query_is_empty(query):


### PR DESCRIPTION
Also, slightly increase retry backoff when reading metrics.

@dlorenc 