### PR TITLE
Record deploy latency data when running deploy check

### DIFF
--- a/integration_tests/deploy_check.py
+++ b/integration_tests/deploy_check.py
@@ -29,10 +29,19 @@ def main():
         parser.add_argument('--directory', '-d', type=str,
                             help='Directory of app to be run',
                             required=True)
+        parser.add_argument('--record_latency', '-r', default=False,
+                            help='Whether record latency data or not',
+                            required=False)
+        parser.add_argument('--language', '-l', type=str,
+                            help='Language of the app deployed',
+                            required=False)
         args = parser.parse_args()
 
         logging.debug('Testing runtime image.')
-        version = deploy_app.deploy_app_without_image(args.directory)
+        version = deploy_app.deploy_app_without_image(
+            args.directory,
+            args.record_latency,
+            args.language)
         application_url = test_util.retrieve_url_for_version(version)
         output, status_code = test_util.get(application_url)
 
@@ -52,3 +61,4 @@ def main():
 
 if __name__ == '__main__':
     sys.exit(main())
+

--- a/integration_tests/deploy_check.py
+++ b/integration_tests/deploy_check.py
@@ -61,4 +61,3 @@ def main():
 
 if __name__ == '__main__':
     sys.exit(main())
-

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+google-cloud-bigquery==0.22.0
 google-cloud-logging==0.22.0
 google-cloud-monitoring==0.22.0
 google-cloud-error-reporting==0.22.0
 retrying==1.3.3
+

--- a/integration_tests/testsuite/deploy_app.py
+++ b/integration_tests/testsuite/deploy_app.py
@@ -14,11 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import logging
 import os
 import subprocess
 import sys
 import test_util
+import time
+
+from google.cloud import bigquery
+
+DATASET_NAME = 'cloudperf'
+DEPLOY_LATENCY_PROJECT_ENV = 'DEPLOY_LATENCY_PROJECT'
+TABLE_NAME = 'deploy_latency'
 
 
 def _cleanup(appdir):
@@ -43,7 +51,26 @@ def _set_builder_image(builder):
                 fout.write(line.replace('${STAGING_BUILDER_IMAGE}', builder))
 
 
-def deploy_app(base_image, builder_image, appdir, yaml):
+def _record_latency_to_bigquery(deploy_latency, language):
+    current_date = datetime.datetime.now()
+    row = [(language, current_date, deploy_latency)]
+
+    project = os.environ.get(DEPLOY_LATENCY_PROJECT_ENV)
+    client = bigquery.Client(project=project)
+    dataset = client.dataset(DATASET_NAME)
+    table = bigquery.Table(name=TABLE_NAME, dataset=dataset)
+    table.reload()
+    error = table.insert_data(row)
+    return error
+
+
+def deploy_app(
+        base_image,
+        builder_image,
+        appdir,
+        yaml,
+        record_latency,
+        language):
     try:
         if yaml:
             # convert yaml to absolute path before changing directory
@@ -68,7 +95,15 @@ def deploy_app(base_image, builder_image, appdir, yaml):
             logging.info(yaml)
             deploy_command.append(yaml)
 
+        start_time = time.time()
         subprocess.check_output(deploy_command)
+
+        # Latency is in seocnds round up to 2 decimals
+        deploy_latency = round(time.time() - start_time, 2)
+
+        # Store the deploy latency data to bigquery
+        if record_latency:
+            _record_latency_to_bigquery(deploy_latency, language)
 
         return deployed_version
     except subprocess.CalledProcessError as cpe:
@@ -81,8 +116,8 @@ def deploy_app(base_image, builder_image, appdir, yaml):
         os.chdir(owd)
 
 
-def deploy_app_without_image(appdir):
-    return deploy_app(None, None, appdir, None)
+def deploy_app_without_image(appdir, record_latency=False, language='unknown'):
+    return deploy_app(None, None, appdir, None, record_latency, language)
 
 
 def stop_app(deployed_version):
@@ -95,3 +130,4 @@ def stop_app(deployed_version):
     except subprocess.CalledProcessError as cpe:
         logging.error('Error encountered when deleting app version! %s',
                       cpe.output)
+

--- a/integration_tests/testsuite/deploy_app.py
+++ b/integration_tests/testsuite/deploy_app.py
@@ -60,17 +60,11 @@ def _record_latency_to_bigquery(deploy_latency, language):
     dataset = client.dataset(DATASET_NAME)
     table = bigquery.Table(name=TABLE_NAME, dataset=dataset)
     table.reload()
-    error = table.insert_data(row)
-    return error
+    return table.insert_data(row)
 
 
-def deploy_app(
-        base_image,
-        builder_image,
-        appdir,
-        yaml,
-        record_latency,
-        language):
+def deploy_app(base_image, builder_image, appdir,
+               yaml, record_latency, language):
     try:
         if yaml:
             # convert yaml to absolute path before changing directory
@@ -98,7 +92,7 @@ def deploy_app(
         start_time = time.time()
         subprocess.check_output(deploy_command)
 
-        # Latency is in seocnds round up to 2 decimals
+        # Latency is in seconds round up to 2 decimals
         deploy_latency = round(time.time() - start_time, 2)
 
         # Store the deploy latency data to bigquery

--- a/integration_tests/testsuite/deploy_app.py
+++ b/integration_tests/testsuite/deploy_app.py
@@ -130,4 +130,3 @@ def stop_app(deployed_version):
     except subprocess.CalledProcessError as cpe:
         logging.error('Error encountered when deleting app version! %s',
                       cpe.output)
-


### PR DESCRIPTION
For #245. This PR is for recording deploy latency data and store it into bigquery table when running deploy check, the data is used for adding a deploy latency metrics to our dashboard.