### PR TITLE
Structure test ext_run script improvement

### DIFF
--- a/structure_tests/ext_run.sh
+++ b/structure_tests/ext_run.sh
@@ -100,7 +100,7 @@ while test $# -gt 0; do
 			if test $# -eq 0; then
 				usage
 			else
-				if [ ! -d "$1" -o ! -d $(readlink -f "$1") ]; then
+				if [ ! -d "$1" || ! -d $(readlink -f "$1") ]; then
 				        echo "$1 is not a valid directory."
 				        cleanup
 				        exit 1

--- a/structure_tests/ext_run.sh
+++ b/structure_tests/ext_run.sh
@@ -100,13 +100,12 @@ while test $# -gt 0; do
 			if test $# -eq 0; then
 				usage
 			else
-				FULLPATH=$(readlink -f "$1")
-				if [ ! -d "$FULLPATH" ]; then
-					echo "$FULLPATH is not a valid directory."
-					cleanup
-					exit 1
+				if [ ! -d "$1" -o ! -d $(readlink -f "$1") ]; then
+				        echo "$1 is not a valid directory."
+				        cleanup
+				        exit 1
 				fi
-
+				FULLPATH=$(readlink -f "$1")
 				VOLUME_STR+=(-v "$FULLPATH:/workspace")
 			fi
 			shift

--- a/structure_tests/ext_run.sh
+++ b/structure_tests/ext_run.sh
@@ -100,7 +100,7 @@ while test $# -gt 0; do
 			if test $# -eq 0; then
 				usage
 			else
-				if [ ! -d "$1" || ! -d $(readlink -f "$1") ]; then
+				if [ ! -d "$1" ] || [ ! -d "$(readlink -f "$1")" ]; then
 				        echo "$1 is not a valid directory."
 				        cleanup
 				        exit 1


### PR DESCRIPTION
Before this change, if the user specified an invalid workspace argument, the `readlink` command can fail silently, returning an empty string (try `readlink -f /foo/bar`). This caused the workspace argument check to be missed (because `[ -d ]` returns true), leading to confusing results later in execution.