### PR TITLE
integration tests: increasing timeout, improved logging

### DIFF
--- a/integration_tests/testsuite/test_monitoring.py
+++ b/integration_tests/testsuite/test_monitoring.py
@@ -41,20 +41,23 @@ class TestMonitoring(unittest.TestCase):
             self.assertEquals(response_code, 0,
                               'Error encountered inside sample application!')
 
-            logging.info('trying to find {0} stored in {1}...'.format(target, metric_name))
+            logging.info('trying to find {0} stored in {1}...'
+                         .format(target, metric_name))
             start = time.time()
             try:
-                found_inserted_token = self._read_metric(metric_name, target, client)
+                found_token = self._read_metric(metric_name, target, client)
                 failure = None
             except Exception as e:
-                found_inserted_token = False
+                found_token = False
                 failure = e
             elapsed = time.time() - start
 
-            logging.info('time elapsed checking for metric: {0}s'.format(elapsed))
+            logging.info('time elapsed checking for metric: {0}s'
+                         .format(elapsed))
 
-            self.assertTrue(found_inserted_token,
-                            'Token not found in Stackdriver monitoring! Last error: {0}'.format(failure))
+            self.assertTrue(found_token,
+                            'Token not found in Stackdriver monitoring!\n'
+                            'Last error: {0}'.format(failure))
         finally:
             self._try_cleanup_metric(client, metric_name)
 
@@ -64,23 +67,26 @@ class TestMonitoring(unittest.TestCase):
             descriptor.delete()
             logging.info('metric {0} deleted'.format(metric_name))
         except Exception as e:
-            logging.warning('Error when deleting metric {0}, manual cleanup might be needed: {1}'
+            logging.warning('Error when deleting metric {0},'
+                            ' manual cleanup might be needed: {1}'
                             .format(metric_name, e.message))
 
     @retry(wait_fixed=5000, stop_max_attempt_number=20)
     def _read_metric(self, name, target, client):
         query = client.query(name, minutes=5)
         if self._no_timeseries_in(query):
-            raise Exception('No timeseries match the query for metric {0}'.format(name))
+            raise Exception('No timeseries match the query for metric {0}'
+                            .format(name))
 
         for timeseries in query:
             for point in timeseries.points:
                 if point.value == target:
-                    logging.info('Token {0} found in Stackdriver '
-                                 'metrics {1}'.format(target, name))
+                    logging.info('Token {0} found in Stackdriver metrics {1}'
+                                 .format(target, name))
                     return True
                 print(point.value)
-        raise Exception('Token {0} not found in metric {1}'.format(target, name))
+        raise Exception('Token {0} not found in metric {1}'
+                        .format(target, name))
 
     def _no_timeseries_in(self, query):
         if query is None:

--- a/integration_tests/testsuite/test_monitoring.py
+++ b/integration_tests/testsuite/test_monitoring.py
@@ -18,6 +18,7 @@ import logging
 from retrying import retry
 import unittest
 import urlparse
+import time
 
 import google.cloud.monitoring
 
@@ -32,33 +33,56 @@ class TestMonitoring(unittest.TestCase):
 
     def runTest(self):
         payload = test_util.generate_metrics_payload()
-        _, response_code = test_util.post(self._url, payload,
-                                          test_util.METRIC_TIMEOUT)
-        self.assertEquals(response_code, 0,
-                          'Error encountered inside sample application!')
-
+        metric_name, target = payload.get('name'), payload.get('token')
         client = google.cloud.monitoring.Client()
 
-        self.assertTrue(self._read_metric(payload.get('name'),
-                                          payload.get('token'), client),
-                        'Token not found in Stackdriver monitoring!')
+        try:
+            _, response_code = test_util.post(self._url, payload,
+                                              test_util.METRIC_TIMEOUT)
+            self.assertEquals(response_code, 0,
+                              'Error encountered inside sample application!')
 
-    @retry(wait_fixed=8000, stop_max_attempt_number=10)
+            logging.info('trying to find {0} stored in {1}...'.format(target, metric_name))
+            start = time.time()
+            try:
+                found_inserted_token = self._read_metric(metric_name, target, client)
+                failure = None
+            except Exception as e:
+                found_inserted_token = False
+                failure = e
+            elapsed = time.time()-start
+
+            logging.info("time elapsed checking for metric: {0}s".format(elapsed))
+
+            self.assertTrue(found_inserted_token, 'Token not found in Stackdriver monitoring! Last error: {0}'.format(failure))
+        finally:
+            self._try_cleanup_metric(client, metric_name)
+
+    def _try_cleanup_metric(self, client, metric_name):
+        try:
+            descriptor = client.metric_descriptor(metric_name)
+            descriptor.delete()
+            logging.info("metric {0} deleted".format(metric_name))
+        except Exception as e:
+            logging.warning("Error when deleting metric {0}, manual cleanup might be needed: {1}"
+                            .format(metric_name, e.message))
+
+    @retry(wait_fixed=5000, stop_max_attempt_number=20)
     def _read_metric(self, name, target, client):
-        query = client.query(name, minutes=2)
-        if self._query_is_empty(query):
-            raise Exception('Metric read retries exceeded!')
+        query = client.query(name, minutes=5)
+        if self._no_timeseries_in(query):
+            raise Exception('No timeseries match the query for metric {0}'.format(name))
 
         for timeseries in query:
             for point in timeseries.points:
                 if point.value == target:
                     logging.info('Token {0} found in Stackdriver '
-                                 'metrics'.format(target))
+                                 'metrics {1}'.format(target, name))
                     return True
                 print(point.value)
-        return False
+        raise Exception('Token {0} not found in metric {1}'.format(target, name))
 
-    def _query_is_empty(self, query):
+    def _no_timeseries_in(self, query):
         if query is None:
             logging.info('query is none')
             return True

--- a/integration_tests/testsuite/test_monitoring.py
+++ b/integration_tests/testsuite/test_monitoring.py
@@ -2,14 +2,14 @@
 
 # Copyright 2017 Google Inc. All rights reserved.
 
-# Licensed under the Apache License, Version 2.0 (the 'License');
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an 'AS IS' BASIS,
+# distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.

--- a/integration_tests/testsuite/test_monitoring.py
+++ b/integration_tests/testsuite/test_monitoring.py
@@ -2,14 +2,14 @@
 
 # Copyright 2017 Google Inc. All rights reserved.
 
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 
 # http://www.apache.org/licenses/LICENSE-2.0
 
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
@@ -26,7 +26,6 @@ import test_util
 
 
 class TestMonitoring(unittest.TestCase):
-
     def __init__(self, url, methodName='runTest'):
         self._url = urlparse.urljoin(url, test_util.MONITORING_ENDPOINT)
         super(TestMonitoring, self).__init__()
@@ -50,11 +49,12 @@ class TestMonitoring(unittest.TestCase):
             except Exception as e:
                 found_inserted_token = False
                 failure = e
-            elapsed = time.time()-start
+            elapsed = time.time() - start
 
-            logging.info("time elapsed checking for metric: {0}s".format(elapsed))
+            logging.info('time elapsed checking for metric: {0}s'.format(elapsed))
 
-            self.assertTrue(found_inserted_token, 'Token not found in Stackdriver monitoring! Last error: {0}'.format(failure))
+            self.assertTrue(found_inserted_token,
+                            'Token not found in Stackdriver monitoring! Last error: {0}'.format(failure))
         finally:
             self._try_cleanup_metric(client, metric_name)
 
@@ -62,9 +62,9 @@ class TestMonitoring(unittest.TestCase):
         try:
             descriptor = client.metric_descriptor(metric_name)
             descriptor.delete()
-            logging.info("metric {0} deleted".format(metric_name))
+            logging.info('metric {0} deleted'.format(metric_name))
         except Exception as e:
-            logging.warning("Error when deleting metric {0}, manual cleanup might be needed: {1}"
+            logging.warning('Error when deleting metric {0}, manual cleanup might be needed: {1}'
                             .format(metric_name, e.message))
 
     @retry(wait_fixed=5000, stop_max_attempt_number=20)


### PR DESCRIPTION
Improving integration tests:  
- **increases timeout** to 100 seconds from 80 (see https://github.com/GoogleCloudPlatform/openjdk-runtime/issues/127 for context)
- **attempts to delete the metric** - even if the POST fails (sometimes metrics might get created!) - however the solution is not perfect, as there might be still situations where the metric is created but times out for the test driver, tries and fails to clean it up, and *then* the metric gets created - hence the warning that manual cleanup might be required. (closes #302)
- **improves logging** - when things failed I found these error messages more helpful 