### PR TITLE
improvements on custom logging tests

### DIFF
--- a/integration_tests/testsuite/test_util.py
+++ b/integration_tests/testsuite/test_util.py
@@ -25,6 +25,7 @@ from retrying import retry
 import string
 import subprocess
 import sys
+import google.auth
 
 requests.packages.urllib3.disable_warnings()
 
@@ -133,9 +134,8 @@ def _check_response(response, error_message):
 
 def project_id():
     try:
-        cmd = ['gcloud', 'config', 'list', '--format=json']
-        entries = json.loads(subprocess.check_output(cmd))
-        return entries.get('core').get('project')
+        _, project = google.auth.default()
+        return project
     except Exception as e:
         logging.error('Error encountered when retrieving project id!')
         logging.error(e)


### PR DESCRIPTION
Adds the following improvements:
* **project id is taken from google auth** - this works well within a docker container with service accounts and the ``GOOGLE_APPLICATION_CREDENTIALS`` env vars quite well, while the previous ``gcloud``based version doesn't. Let me know if this would break something else 
* **filter** 
  * is logged (so it's easy to double check on the UI) and created only once
  * adds severity (so that we are testing that too!)
  * adds resource as global (well, this is where this might break things) - it's so much faster if you specify a resource as well, it doesn't have to iterate through all the monitored resources to find a matching log name
