### PR TITLE
Change the order of the log entries, also limit the num entries.

### DIFF
--- a/integration_tests/testsuite/test_logging_standard.py
+++ b/integration_tests/testsuite/test_logging_standard.py
@@ -59,7 +59,9 @@ class TestStandardLogging(unittest.TestCase):
                  '{1} AND textPayload:"{2}"'.format(project_id,
                                                     log_name,
                                                     test_util.LOGGING_PREFIX)
-        for entry in client.list_entries(filter_=FILTER):
+        for entry in client.list_entries(filter_=FILTER,
+                                         order_by='timestamp desc',
+                                         page_size=10):
             # since the logs we're examining are for the deployed flex app,
             # we can safely log from the test driver without contaminating
             # the logs under examination.


### PR DESCRIPTION
Motivation:

The integration test took more then 2 hours for us. My suspicion is the API call is taking very long time (with many empty responses with a page token), because it scans all of the logs on the server side.

Descending order might help here. I ran the PHP test against my project and it passed, although I could not run the test against the real project we used on our jenkins instance due to lack of permission, so that I'm not 100% sure it's going to resolve the slow test, but I'm somewhat confident.