### PR TITLE
Support GKE in Integration Tests

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -139,6 +139,31 @@ The driver will then enter two phases for each test:
 * The Execution: the driver will make sequential requests to each of the specified paths and store the results.
 * The Validation: the results of the executions will be asserted using the provided specification.
 
+One final requirement for the test driver is that it exposes the cloud environment where it is deployed to the test driver. This allows the driver to dynamically test different scenarios depending on the environment (e.g. log location). **The test application must expose its cloud environment at http://<application_url>/environment!** Tests will not function properly otherwise.
+
+At this URL, the application should return the cloud environment where it itself is deployed, in the form of a string. Valid return values in the response are:
+
+* `'GAE'`
+* `'GKE'`
+
+There are a few ways to retrieve this information from within the deployed application. A generally accepted way is to check for GAE-specific environment variables on the host; these are always set by GAE upon deploy, so if they don't exist we know we're not on GAE, and can assume we're deployed in a GKE cluster.
+
+For example, the implementation in the python application:
+
+```
+_APPENGINE_FLEXIBLE_ENV_VM = 'GAE_APPENGINE_HOSTNAME'
+"""Environment variable set in App Engine when vm:true is set."""
+
+_APPENGINE_FLEXIBLE_ENV_FLEX = 'GAE_INSTANCE'
+"""Environment variable set in App Engine when env:flex is set."""
+
+...
+
+return (_APPENGINE_FLEXIBLE_ENV_VM in os.environ or
+        _APPENGINE_FLEXIBLE_ENV_FLEX in os.environ), 200
+```
+
+
 #### The Execution phase
 The execution can be configured using the field `steps`. This field contains an array of `Step`, where each `Step` represent a request 
 and an associated configuration, a `Step` is defined using the following schema:

--- a/integration_tests/deploy_check.py
+++ b/integration_tests/deploy_check.py
@@ -86,16 +86,16 @@ def _deploy_and_test(appdir, language, is_xrt):
     version = None
     try:
         logging.debug('Testing runtime image.')
-        version = deploy_app.deploy_app_and_record_latency(appdir,
-                                                           language, is_xrt)
+        version, url = deploy_app.deploy_app_and_record_latency(appdir,
+                                                                language,
+                                                                is_xrt)
         application_url = test_util.retrieve_url_for_version(version)
         _test_application(application_url)
     except Exception as e:
-        logging.error('Error when contacting application!')
-        logging.error(e)
+        logging.error('Error when contacting application! %s', e)
     finally:
         if version:
-            deploy_app.stop_app(version)
+            deploy_app.stop_version(version)
 
 
 @retry(wait_fixed=4000, stop_max_attempt_number=8)

--- a/integration_tests/testsuite/constants.py
+++ b/integration_tests/testsuite/constants.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+
+CLUSTER_NAME = 'gcp-integration-test-cluster'
+
+LOGNAME_LENGTH = 16
+
+LOGGING_PREFIX = 'GCP_INTEGRATION_TEST_'
+
+DEFAULT_TIMEOUT = 30  # seconds
+
+ROOT_ENDPOINT = '/'
+ROOT_EXPECTED_OUTPUT = 'Hello World!'
+
+STANDARD_LOGGING_ENDPOINT = '/logging_standard'
+CUSTOM_LOGGING_ENDPOINT = '/logging_custom'
+MONITORING_ENDPOINT = '/monitoring'
+EXCEPTION_ENDPOINT = '/exception'
+CUSTOM_ENDPOINT = '/custom'
+ENVIRONMENT_ENDPOINT = '/environment'
+
+METRIC_PREFIX = 'custom.googleapis.com/{0}'
+METRIC_TIMEOUT = 60  # seconds
+
+# subset of levels found at
+# https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
+SEVERITIES = [
+    'WARNING',
+    'ERROR',
+    'CRITICAL'
+]
+
+GAE = 'GAE'
+GKE = 'GKE'
+ENVS = [GAE, GKE]

--- a/integration_tests/testsuite/template.py
+++ b/integration_tests/testsuite/template.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+
+GKE_TEMPLATE = '''apiVersion: v1
+kind: Service
+metadata:
+  name: {service_name}
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: {service_name}-app
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {service_name}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: {service_name}
+      labels:
+        app: {service_name}-app
+    spec:
+      containers:
+      - name: {service_name}
+        image: {test_image}
+        resources:
+          requests:
+            cpu: 100m
+            memory: "512Mi"
+          limits:
+            cpu: 200m
+            memory: "1024Mi"
+        env:
+        - name: HEAP_SIZE_RATIO
+          value: "50"
+        ports:
+        - containerPort: 8080
+
+'''

--- a/integration_tests/testsuite/template.py
+++ b/integration_tests/testsuite/template.py
@@ -27,16 +27,6 @@ spec:
       containers:
       - name: {service_name}
         image: {test_image}
-        resources:
-          requests:
-            cpu: 100m
-            memory: "512Mi"
-          limits:
-            cpu: 200m
-            memory: "1024Mi"
-        env:
-        - name: HEAP_SIZE_RATIO
-          value: "50"
         ports:
         - containerPort: 8080
 

--- a/integration_tests/testsuite/test_custom.py
+++ b/integration_tests/testsuite/test_custom.py
@@ -21,6 +21,7 @@ import requests
 import unittest
 import urlparse
 
+import constants
 import test_util
 
 
@@ -38,7 +39,7 @@ class TestCustom(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
         self._base_url = url
-        self._url = urlparse.urljoin(url, test_util.CUSTOM_ENDPOINT)
+        self._url = urlparse.urljoin(url, constants.CUSTOM_ENDPOINT)
         unittest.TestCase.__init__(self)
 
     def runTest(self):

--- a/integration_tests/testsuite/test_exception.py
+++ b/integration_tests/testsuite/test_exception.py
@@ -18,13 +18,14 @@ import logging
 import unittest
 import urlparse
 
+import constants
 import test_util
 
 
 class TestException(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
-        self._url = urlparse.urljoin(url, test_util.EXCEPTION_ENDPOINT)
+        self._url = urlparse.urljoin(url, constants.EXCEPTION_ENDPOINT)
         super(TestException, self).__init__()
 
     def runTest(self):

--- a/integration_tests/testsuite/test_monitoring.py
+++ b/integration_tests/testsuite/test_monitoring.py
@@ -22,12 +22,13 @@ import time
 
 import google.cloud.monitoring
 
+import constants
 import test_util
 
 
 class TestMonitoring(unittest.TestCase):
     def __init__(self, url, methodName='runTest'):
-        self._url = urlparse.urljoin(url, test_util.MONITORING_ENDPOINT)
+        self._url = urlparse.urljoin(url, constants.MONITORING_ENDPOINT)
         super(TestMonitoring, self).__init__()
 
     def runTest(self):
@@ -37,7 +38,7 @@ class TestMonitoring(unittest.TestCase):
 
         try:
             _, response_code = test_util.post(self._url, payload,
-                                              test_util.METRIC_TIMEOUT)
+                                              constants.METRIC_TIMEOUT)
             self.assertEquals(response_code, 0,
                               'Error encountered inside sample application!')
 

--- a/integration_tests/testsuite/test_root.py
+++ b/integration_tests/testsuite/test_root.py
@@ -15,19 +15,21 @@
 # limitations under the License.
 
 import logging
-from retrying import retry
 import unittest
 import urlparse
+from retrying import retry
 
+import constants
 import test_util
 
 
 class TestRoot(unittest.TestCase):
 
     def __init__(self, url, methodName='runTest'):
-        self._url = urlparse.urljoin(url, test_util.ROOT_ENDPOINT)
+        self._url = urlparse.urljoin(url, constants.ROOT_ENDPOINT)
         super(TestRoot, self).__init__()
 
+    @retry(wait_fixed=4000, stop_max_attempt_number=8)
     def runTest(self):
         self._test_root()
 
@@ -39,6 +41,6 @@ class TestRoot(unittest.TestCase):
         if status_code != 0:
             raise Exception('Cannot connect to sample application!')
 
-        self.assertEquals(output, test_util.ROOT_EXPECTED_OUTPUT,
+        self.assertEquals(output, constants.ROOT_EXPECTED_OUTPUT,
                           'Unexpected output: expected {0}, received {1}'
-                          .format(test_util.ROOT_EXPECTED_OUTPUT, output))
+                          .format(constants.ROOT_EXPECTED_OUTPUT, output))

--- a/integration_tests/testsuite/test_util.py
+++ b/integration_tests/testsuite/test_util.py
@@ -23,47 +23,23 @@ import random
 import requests
 from retrying import retry
 import string
-import subprocess
-import sys
+from subprocess import Popen, PIPE, check_output, CalledProcessError
 import google.auth
 
+import constants
+
 requests.packages.urllib3.disable_warnings()
-
-LOGNAME_LENGTH = 16
-
-LOGGING_PREFIX = 'GCP_INTEGRATION_TEST_'
-
-DEFAULT_TIMEOUT = 30  # seconds
-
-ROOT_ENDPOINT = '/'
-ROOT_EXPECTED_OUTPUT = 'Hello World!'
-
-STANDARD_LOGGING_ENDPOINT = '/logging_standard'
-CUSTOM_LOGGING_ENDPOINT = '/logging_custom'
-MONITORING_ENDPOINT = '/monitoring'
-EXCEPTION_ENDPOINT = '/exception'
-CUSTOM_ENDPOINT = '/custom'
-
-METRIC_PREFIX = 'custom.googleapis.com/{0}'
-METRIC_TIMEOUT = 60  # seconds
-
-# subset of levels found at
-# https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
-SEVERITIES = [
-    'WARNING',
-    'ERROR',
-    'CRITICAL'
-]
 
 
 def _generate_name():
     name = ''.join(random.choice(string.ascii_uppercase +
-                   string.ascii_lowercase) for i in range(LOGNAME_LENGTH))
+                   string.ascii_lowercase)
+                   for i in range(constants.LOGNAME_LENGTH))
     return name
 
 
-def _generate_hex_token():
-    return binascii.b2a_hex(os.urandom(16))
+def _generate_hex_token(num_bytes):
+    return binascii.b2a_hex(os.urandom(num_bytes))
 
 
 def _generate_int64_token():
@@ -72,17 +48,17 @@ def _generate_int64_token():
 
 def generate_logging_payloads():
     payloads = []
-    for s in SEVERITIES:
+    for s in constants.SEVERITIES:
         payloads.append({
             'log_name': _generate_name(),
-            'token': LOGGING_PREFIX + _generate_hex_token(),
+            'token': constants.LOGGING_PREFIX + _generate_hex_token(16),
             'level': s
             })
     return payloads
 
 
 def generate_metrics_payload():
-    data = {'name': METRIC_PREFIX.format(_generate_name()),
+    data = {'name': constants.METRIC_PREFIX.format(_generate_name()),
             'token': _generate_int64_token()}
     return data
 
@@ -92,7 +68,7 @@ def generate_exception_payload():
     return data
 
 
-def get(url, timeout=DEFAULT_TIMEOUT):
+def get(url, timeout=constants.DEFAULT_TIMEOUT):
     logging.info('Making GET request to url {0}'.format(url))
     try:
         response = requests.get(url)
@@ -107,7 +83,7 @@ def get(url, timeout=DEFAULT_TIMEOUT):
         return None, 1
 
 
-def post(url, payload, timeout=DEFAULT_TIMEOUT):
+def post(url, payload, timeout=constants.DEFAULT_TIMEOUT):
     try:
         headers = {'Content-Type': 'application/json'}
         response = requests.post(url,
@@ -153,9 +129,65 @@ def retrieve_url_for_version(version):
         url_command = ['gcloud', 'app', 'versions', 'describe',
                        version, '--service',
                        'default', '--format=json']
-        app_dict = json.loads(subprocess.check_output(url_command))
+        app_dict = json.loads(check_output(url_command))
         return app_dict.get('versionUrl')
-    except (subprocess.CalledProcessError, ValueError, KeyError) as e:
-        logging.warn('Error encountered when retrieving app URL! %s', e)
-        sys.exit(1)
+    except (CalledProcessError, ValueError, KeyError) as e:
+        logging.error('Error encountered when retrieving app URL! %s', e)
+        raise
     raise Exception('Unable to contact deployed application!')
+
+
+def generate_gke_image_name():
+    return 'gcr.io/{project}/{image}'.format(
+        project=project_id(),
+        image=_generate_hex_token(8)
+    )
+
+
+def generate_gke_service_name():
+    return 'gcp-integration-test-{0}'.format(_generate_hex_token(8))
+
+
+def generate_namespace():
+    return 'int-test-{0}'.format(_generate_hex_token(8))
+
+
+@retry(wait_exponential_multiplier=1000, wait_exponential_max=32000,
+       stop_max_attempt_number=12)
+def get_external_ip_for_cluster(service_name, namespace):
+    logging.info('Waiting for deployment external IP...')
+    ip_command = ['kubectl', 'get', 'services', service_name,
+                  '--namespace', namespace, '--output=json']
+    service = json.loads(execute_command(ip_command))
+    ip = service['status']['loadBalancer']['ingress'][0]['ip']
+    return 'http://{0}:80'.format(ip)
+
+
+def get_environment(base_url):
+    env_url = base_url + constants.ENVIRONMENT_ENDPOINT
+    env, resp = get(env_url)
+    if not env:
+        logging.error('Error when retrieving environment from application')
+        logging.error('Defaulting to GAE')
+        return constants.GAE
+    return env
+
+
+def execute_command(command, print_output=False, stdin=None):
+    logging.debug(command)
+    proc = Popen(command, shell=False, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+
+    if stdin:
+        output, err = proc.communicate(stdin)
+    else:
+        output, err = proc.communicate()
+    exitCode = proc.returncode
+
+    if exitCode != 0:
+        raise Exception(err)
+
+    logging.debug(output)
+    if print_output:
+        logging.info(output)
+
+    return output


### PR DESCRIPTION
This PR adds support for automated deploy and testing of sample applications in GKE for all runtimes. It assumes a cluster called `gcp-integration-test-cluster` exists and that we can freely access it (the auth we have set up in the actual jobs should work fine for this). Random image, service, and namespace names are generated by the driver, and substituted into a templated Kubernetes yaml file, which is then used to create the deployment. Tests are then run as normal, and once finished, the created services and namespace are deleted.

~We will need to update the integration test applications to be smarter about their logging sources that they return to the test driver, because they're currently hardcoded to return an App Engine specific source. I'm still working on this for the Python application.~

We'll need to update the integration test applications to expose an endpoint, `/environment`, that tells the test driver what cloud environment (GAE or GKE) they're deployed in. This allows the test driver to read logs from the correct location.

@dlorenc @duggelz 