### PR TITLE
add retries to root test before running other integration tests

### DIFF
--- a/integration_tests/testsuite/test_root.py
+++ b/integration_tests/testsuite/test_root.py
@@ -29,10 +29,10 @@ class TestRoot(unittest.TestCase):
         super(TestRoot, self).__init__()
 
     def runTest(self):
-        test_root()
+        self._test_root()
 
     @retry(wait_fixed=4000, stop_max_attempt_number=8)
-    def test_root(self):
+    def _test_root(self):
         logging.debug('Hitting endpoint: {0}'.format(self._url))
         output, status_code = test_util.get(self._url)
         logging.info('output is: {0}'.format(output))

--- a/integration_tests/testsuite/test_root.py
+++ b/integration_tests/testsuite/test_root.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import logging
+from retrying import retry
 import unittest
 import urlparse
 
@@ -28,11 +29,15 @@ class TestRoot(unittest.TestCase):
         super(TestRoot, self).__init__()
 
     def runTest(self):
+        test_root()
+
+    @retry(wait_fixed=4000, stop_max_attempt_number=8)
+    def test_root(self):
         logging.debug('Hitting endpoint: {0}'.format(self._url))
         output, status_code = test_util.get(self._url)
         logging.info('output is: {0}'.format(output))
-        self.assertEquals(status_code, 0,
-                          'Cannot connect to sample application!')
+        if status_code != 0:
+            raise Exception('Cannot connect to sample application!')
 
         self.assertEquals(output, test_util.ROOT_EXPECTED_OUTPUT,
                           'Unexpected output: expected {0}, received {1}'


### PR DESCRIPTION
this will give the deployed application some time to come up before we try and run the tests. should eliminate some flakiness.

@dlorenc 