### PR TITLE
Use the whole token for the filter

### DIFF
--- a/integration_tests/testsuite/test_logging_standard.py
+++ b/integration_tests/testsuite/test_logging_standard.py
@@ -54,7 +54,7 @@ class TestStandardLogging(unittest.TestCase):
             FILTER = 'logName = projects/{0}/logs/{1} ' \
                      'AND textPayload:"{2}"'.format(project_id,
                                                     log_name,
-                                                    test_util.LOGGING_PREFIX)
+                                                    token)
 
             logging.info('logging filter: {0}'.format(FILTER))
             self.assertTrue(self._read_log(client, token, FILTER),


### PR DESCRIPTION

Rationale:

We used to use the `test_util.LOGGING_PREFIX` for the filter. It works most of the times, but if we run bunch of integration tests at the same time, the tests may start to fail because the log entry in question might not fit in a single page. We can just safely use the whole token for the filter.