### PR TITLE
rename command args to match k8s in schema v1.1.0

### DIFF
--- a/structure_tests/command_test_v0.go
+++ b/structure_tests/command_test_v0.go
@@ -19,27 +19,26 @@ import (
 	"testing"
 )
 
-type CommandTestv1 struct {
+type CommandTestv0 struct {
 	Name           string
 	Setup          []Command
 	Teardown       []Command
 	EnvVars        []EnvVar
 	ExitCode       int
 	ShellMode      bool
-	Entrypoint     string
-	Args           []string
+	Command        []string
 	ExpectedOutput []string
 	ExcludedOutput []string
 	ExpectedError  []string
 	ExcludedError  []string // excluded error from running command
 }
 
-func validateCommandTestv1(t *testing.T, tt CommandTestv1) {
+func validateCommandTestv0(t *testing.T, tt CommandTestv0) {
 	if tt.Name == "" {
 		t.Fatalf("Please provide a valid name for every test!")
 	}
-	if tt.Entrypoint == "" {
-		t.Fatalf("Please provide a valid entrypoint to run for test %s", tt.Name)
+	if tt.Command == nil || len(tt.Command) == 0 {
+		t.Fatalf("Please provide a valid command to run for test %s", tt.Name)
 	}
 	if tt.Setup != nil {
 		for _, c := range tt.Setup {
@@ -56,14 +55,14 @@ func validateCommandTestv1(t *testing.T, tt CommandTestv1) {
 		}
 	}
 	if tt.EnvVars != nil {
-		for _, env_var := range tt.EnvVars {
-			if env_var.Key == "" || env_var.Value == "" {
-				t.Fatalf("Please provide non-empty keys and values for all specified env_vars")
+		for _, envVar := range tt.EnvVars {
+			if envVar.Key == "" || envVar.Value == "" {
+				t.Fatalf("Please provide non-empty keys and values for all specified env vars")
 			}
 		}
 	}
 }
 
-func (ct CommandTestv1) LogName() string {
+func (ct CommandTestv0) LogName() string {
 	return fmt.Sprintf("Command Test: %s", ct.Name)
 }

--- a/structure_tests/file_content_test_v0.go
+++ b/structure_tests/file_content_test_v0.go
@@ -19,14 +19,14 @@ import (
 	"testing"
 )
 
-type FileContentTestv1 struct {
+type FileContentTestv0 struct {
 	Name             string   // name of test
 	Path             string   // file to check existence of
 	ExpectedContents []string // list of expected contents of file
 	ExcludedContents []string // list of excluded contents of file
 }
 
-func validateFileContentTestV1(t *testing.T, tt FileContentTestv1) {
+func validateFileContentTestv0(t *testing.T, tt FileContentTestv0) {
 	if tt.Name == "" {
 		t.Fatalf("Please provide a valid name for every test!")
 	}
@@ -35,6 +35,6 @@ func validateFileContentTestV1(t *testing.T, tt FileContentTestv1) {
 	}
 }
 
-func (ft FileContentTestv1) LogName() string {
+func (ft FileContentTestv0) LogName() string {
 	return fmt.Sprintf("File Content Test: %s", ft.Name)
 }

--- a/structure_tests/file_existence_test_v0.go
+++ b/structure_tests/file_existence_test_v0.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 )
 
-type FileExistenceTestv1 struct {
+type FileExistenceTestv0 struct {
 	Name        string // name of test
 	Path        string // file to check existence of
 	IsDirectory bool   // whether or not the path points to a directory
@@ -27,7 +27,7 @@ type FileExistenceTestv1 struct {
 	Permissions string // expected Unix permission string of the file, e.g. drwxrwxrwx
 }
 
-func validateFileExistenceTestV1(t *testing.T, tt FileExistenceTestv1) {
+func validateFileExistenceTestv0(t *testing.T, tt FileExistenceTestv0) {
 	if tt.Name == "" {
 		t.Fatalf("Please provide a valid name for every test!")
 	}
@@ -36,6 +36,6 @@ func validateFileExistenceTestV1(t *testing.T, tt FileExistenceTestv1) {
 	}
 }
 
-func (ft FileExistenceTestv1) LogName() string {
+func (ft FileExistenceTestv0) LogName() string {
 	return fmt.Sprintf("File Existence Test: %s", ft.Name)
 }

--- a/structure_tests/licenses_test_v0.go
+++ b/structure_tests/licenses_test_v0.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Not currently used, but leaving the possibility open
-type LicenseTestv1 struct {
+type LicenseTestv0 struct {
 	Debian bool
 	Files  []string
 }
@@ -41,7 +41,7 @@ func checkFile(t *testing.T, licenseFile string) {
 	}
 }
 
-func checkLicenses(t *testing.T, tt LicenseTestv1) {
+func checkLicenses(t *testing.T, tt LicenseTestv0) {
 	if tt.Debian {
 		root := "/usr/share/doc"
 		packages, err := ioutil.ReadDir(root)
@@ -84,6 +84,6 @@ func checkLicenses(t *testing.T, tt LicenseTestv1) {
 	}
 }
 
-func (lt LicenseTestv1) LogName(num int) string {
+func (lt LicenseTestv0) LogName(num int) string {
 	return fmt.Sprintf("License Test #%d", num)
 }

--- a/structure_tests/structure_test.go
+++ b/structure_tests/structure_test.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -46,17 +45,6 @@ func TestAll(t *testing.T) {
 	}
 }
 
-func compileAndRunRegex(regex string, base string, t *testing.T, err string, shouldMatch bool) {
-	r, rErr := regexp.Compile(regex)
-	if rErr != nil {
-		t.Errorf("Error compiling regex %s : %s", regex, rErr.Error())
-		return
-	}
-	if shouldMatch != r.MatchString(base) {
-		t.Errorf(err)
-	}
-}
-
 func Parse(fp string) (StructureTest, error) {
 	testContents, err := ioutil.ReadFile(fp)
 	if err != nil {
@@ -72,7 +60,7 @@ func Parse(fp string) (StructureTest, error) {
 	case strings.HasSuffix(fp, ".yaml"):
 		unmarshal = yaml.Unmarshal
 	default:
-		return nil, errors.New("Please provide valid JSON or YAML config file.")
+		return nil, errors.New("Please provide valid JSON or YAML config file")
 	}
 
 	if err := unmarshal(testContents, &versionHolder); err != nil {
@@ -81,7 +69,7 @@ func Parse(fp string) (StructureTest, error) {
 
 	version := versionHolder.SchemaVersion
 	if version == "" {
-		return nil, errors.New("Please provide JSON schema version.")
+		return nil, errors.New("Please provide JSON schema version")
 	}
 	st := schemaVersions[version]
 	if st == nil {
@@ -93,7 +81,7 @@ func Parse(fp string) (StructureTest, error) {
 	unmarshal(testContents, testHolder)
 	tests, ok := testHolder.(StructureTest) //type assertion
 	if !ok {
-		return nil, errors.New("Error encountered when type casting Structure Test interface!")
+		return nil, errors.New("Error encountered when type casting Structure Test interface")
 	}
 	return tests, nil
 }
@@ -101,7 +89,7 @@ func Parse(fp string) (StructureTest, error) {
 var configFiles arrayFlags
 
 func TestMain(m *testing.M) {
-	flag.Var(&configFiles, "config", "path to the .yaml file containing test definitions.")
+	flag.Var(&configFiles, "config", "path to the .yaml file containing test definitions")
 	flag.Parse()
 
 	if len(configFiles) == 0 {

--- a/structure_tests/structure_test_v000.go
+++ b/structure_tests/structure_test_v000.go
@@ -25,15 +25,15 @@ import (
 	"testing"
 )
 
-type StructureTestv1 struct {
+type StructureTestv000 struct {
 	GlobalEnvVars      []EnvVar
-	CommandTests       []CommandTestv1
-	FileExistenceTests []FileExistenceTestv1
-	FileContentTests   []FileContentTestv1
-	LicenseTests       []LicenseTestv1
+	CommandTests       []CommandTestv0
+	FileExistenceTests []FileExistenceTestv0
+	FileContentTests   []FileContentTestv0
+	LicenseTests       []LicenseTestv0
 }
 
-func (st StructureTestv1) RunAll(t *testing.T) int {
+func (st StructureTestv000) RunAll(t *testing.T) int {
 	originalVars := SetEnvVars(t, st.GlobalEnvVars)
 	defer ResetEnvVars(t, originalVars)
 	testsRun := 0
@@ -44,17 +44,17 @@ func (st StructureTestv1) RunAll(t *testing.T) int {
 	return testsRun
 }
 
-func (st StructureTestv1) RunCommandTests(t *testing.T) int {
+func (st StructureTestv000) RunCommandTests(t *testing.T) int {
 	counter := 0
 	for _, tt := range st.CommandTests {
 		t.Run(tt.LogName(), func(t *testing.T) {
-			validateCommandTestV1(t, tt)
+			validateCommandTestv0(t, tt)
 			for _, setup := range tt.Setup {
 				ProcessCommand(t, tt.EnvVars, setup, tt.ShellMode, false)
 			}
 
 			stdout, stderr, exitcode := ProcessCommand(t, tt.EnvVars, tt.Command, tt.ShellMode, true)
-			CheckOutput(t, tt, stdout, stderr, exitcode)
+			CheckOutputv0(t, tt, stdout, stderr, exitcode)
 
 			for _, teardown := range tt.Teardown {
 				ProcessCommand(t, tt.EnvVars, teardown, tt.ShellMode, false)
@@ -65,11 +65,11 @@ func (st StructureTestv1) RunCommandTests(t *testing.T) int {
 	return counter
 }
 
-func (st StructureTestv1) RunFileExistenceTests(t *testing.T) int {
+func (st StructureTestv000) RunFileExistenceTests(t *testing.T) int {
 	counter := 0
 	for _, tt := range st.FileExistenceTests {
 		t.Run(tt.LogName(), func(t *testing.T) {
-			validateFileExistenceTestV1(t, tt)
+			validateFileExistenceTestv0(t, tt)
 			var err error
 			var info os.FileInfo
 			if tt.IsDirectory {
@@ -102,11 +102,11 @@ func (st StructureTestv1) RunFileExistenceTests(t *testing.T) int {
 	return counter
 }
 
-func (st StructureTestv1) RunFileContentTests(t *testing.T) int {
+func (st StructureTestv000) RunFileContentTests(t *testing.T) int {
 	counter := 0
 	for _, tt := range st.FileContentTests {
 		t.Run(tt.LogName(), func(t *testing.T) {
-			validateFileContentTestV1(t, tt)
+			validateFileContentTestv0(t, tt)
 			actualContents, err := ioutil.ReadFile(tt.Path)
 			if err != nil {
 				t.Errorf("Failed to open %s. Error: %s", tt.Path, err)
@@ -129,7 +129,7 @@ func (st StructureTestv1) RunFileContentTests(t *testing.T) int {
 	return counter
 }
 
-func (st StructureTestv1) RunLicenseTests(t *testing.T) int {
+func (st StructureTestv000) RunLicenseTests(t *testing.T) int {
 	for num, tt := range st.LicenseTests {
 		t.Run(tt.LogName(num), func(t *testing.T) {
 			checkLicenses(t, tt)
@@ -143,7 +143,7 @@ func (st StructureTestv1) RunLicenseTests(t *testing.T) int {
 // current environment. a list of environment variables can be passed to be set in the
 // environment before the command is executed. additionally, a boolean flag is passed
 // to specify whether or not we care about the output of the command.
-func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string,
+func ProcessCommandv0(t *testing.T, envVars []EnvVar, fullCommand []string,
 	shellMode bool, checkOutput bool) (string, string, int) {
 	var cmd *exec.Cmd
 	if len(fullCommand) == 0 {
@@ -210,37 +210,7 @@ func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string,
 	return stdout, stderr, exitCode
 }
 
-// given a list of environment variable key/value pairs, set these in the current environment.
-// also, keep track of the previous values of these vars to reset after test execution.
-func SetEnvVars(t *testing.T, vars []EnvVar) []EnvVar {
-	var originalVars []EnvVar
-	for _, env_var := range vars {
-		originalVars = append(originalVars, EnvVar{env_var.Key, os.Getenv(env_var.Key)})
-		if err := os.Setenv(env_var.Key, os.ExpandEnv(env_var.Value)); err != nil {
-			t.Fatalf("error setting env var: %s", err)
-		}
-	}
-	return originalVars
-}
-
-func ResetEnvVars(t *testing.T, vars []EnvVar) {
-	for _, env_var := range vars {
-		var err error
-		if env_var.Value == "" {
-			// if the previous value was empty string, the variable did not
-			// exist in the environment; unset it
-			err = os.Unsetenv(env_var.Key)
-		} else {
-			// otherwise, set it back to its previous value
-			err = os.Setenv(env_var.Key, env_var.Value)
-		}
-		if err != nil {
-			t.Fatalf("error resetting env var: %s", err)
-		}
-	}
-}
-
-func CheckOutput(t *testing.T, tt CommandTestv1, stdout string, stderr string, exitCode int) {
+func CheckOutputv0(t *testing.T, tt CommandTestv0, stdout string, stderr string, exitCode int) {
 	for _, errStr := range tt.ExpectedError {
 		errMsg := fmt.Sprintf("Expected string '%s' not found in error!", errStr)
 		compileAndRunRegex(errStr, stderr, t, errMsg, true)

--- a/structure_tests/structure_test_v100.go
+++ b/structure_tests/structure_test_v100.go
@@ -1,0 +1,160 @@
+// Copyright 2017 Google Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+type StructureTestv100 struct {
+	GlobalEnvVars      []EnvVar
+	CommandTests       []CommandTestv1
+	FileExistenceTests []FileExistenceTestv0
+	FileContentTests   []FileContentTestv0
+	LicenseTests       []LicenseTestv0
+}
+
+func (st StructureTestv100) RunAll(t *testing.T) int {
+	originalVars := SetEnvVars(t, st.GlobalEnvVars)
+	defer ResetEnvVars(t, originalVars)
+	testsRun := 0
+	testsRun += st.RunCommandTests(t)
+	testsRun += st.RunFileExistenceTests(t)
+	testsRun += st.RunFileContentTests(t)
+	testsRun += st.RunLicenseTests(t)
+	return testsRun
+}
+
+func (st StructureTestv100) RunCommandTests(t *testing.T) int {
+	counter := 0
+	for _, tt := range st.CommandTests {
+		t.Run(tt.LogName(), func(t *testing.T) {
+			validateCommandTestv1(t, tt)
+			for _, setup := range tt.Setup {
+				ProcessCommand(t, tt.EnvVars, setup, tt.ShellMode, false)
+			}
+
+			fullCommand := append([]string{tt.Entrypoint}, tt.Args...)
+
+			stdout, stderr, exitcode := ProcessCommand(t, tt.EnvVars, fullCommand, tt.ShellMode, true)
+			CheckOutputv1(t, tt, stdout, stderr, exitcode)
+
+			for _, teardown := range tt.Teardown {
+				ProcessCommand(t, tt.EnvVars, teardown, tt.ShellMode, false)
+			}
+			counter++
+		})
+	}
+	return counter
+}
+
+func (st StructureTestv100) RunFileExistenceTests(t *testing.T) int {
+	counter := 0
+	for _, tt := range st.FileExistenceTests {
+		t.Run(tt.LogName(), func(t *testing.T) {
+			validateFileExistenceTestv0(t, tt)
+			var err error
+			var info os.FileInfo
+			if tt.IsDirectory {
+				info, err = os.Stat(tt.Path)
+			} else {
+				info, err = os.Stat(tt.Path)
+			}
+			if tt.ShouldExist && err != nil {
+				if tt.IsDirectory {
+					t.Errorf("Directory %s should exist but does not!", tt.Path)
+				} else {
+					t.Errorf("File %s should exist but does not!", tt.Path)
+				}
+			} else if !tt.ShouldExist && err == nil {
+				if tt.IsDirectory {
+					t.Errorf("Directory %s should not exist but does!", tt.Path)
+				} else {
+					t.Errorf("File %s should not exist but does!", tt.Path)
+				}
+			}
+			if tt.Permissions != "" {
+				perms := info.Mode()
+				if perms.String() != tt.Permissions {
+					t.Errorf("%s has incorrect permissions. Expected: %s, Actual: %s", tt.Path, tt.Permissions, perms.String())
+				}
+			}
+			counter++
+		})
+	}
+	return counter
+}
+
+func (st StructureTestv100) RunFileContentTests(t *testing.T) int {
+	counter := 0
+	for _, tt := range st.FileContentTests {
+		t.Run(tt.LogName(), func(t *testing.T) {
+			validateFileContentTestv0(t, tt)
+			actualContents, err := ioutil.ReadFile(tt.Path)
+			if err != nil {
+				t.Errorf("Failed to open %s. Error: %s", tt.Path, err)
+			}
+
+			contents := string(actualContents[:])
+
+			var errMessage string
+			for _, s := range tt.ExpectedContents {
+				errMessage = "Expected string " + s + " not found in file contents!"
+				compileAndRunRegex(s, contents, t, errMessage, true)
+			}
+			for _, s := range tt.ExcludedContents {
+				errMessage = "Excluded string " + s + " found in file contents!"
+				compileAndRunRegex(s, contents, t, errMessage, false)
+			}
+			counter++
+		})
+	}
+	return counter
+}
+
+func (st StructureTestv100) RunLicenseTests(t *testing.T) int {
+	for num, tt := range st.LicenseTests {
+		t.Run(tt.LogName(num), func(t *testing.T) {
+			checkLicenses(t, tt)
+		})
+		return 1
+	}
+	return 0
+}
+
+func CheckOutputv1(t *testing.T, tt CommandTestv1, stdout string, stderr string, exitCode int) {
+	for _, errStr := range tt.ExpectedError {
+		errMsg := fmt.Sprintf("Expected string '%s' not found in error!", errStr)
+		compileAndRunRegex(errStr, stderr, t, errMsg, true)
+	}
+	for _, errStr := range tt.ExcludedError {
+		errMsg := fmt.Sprintf("Excluded string '%s' found in error!", errStr)
+		compileAndRunRegex(errStr, stderr, t, errMsg, false)
+	}
+	for _, outStr := range tt.ExpectedOutput {
+		errMsg := fmt.Sprintf("Expected string '%s' not found in output!", outStr)
+		compileAndRunRegex(outStr, stdout, t, errMsg, true)
+	}
+	for _, outStr := range tt.ExcludedOutput {
+		errMsg := fmt.Sprintf("Excluded string '%s' found in output!", outStr)
+		compileAndRunRegex(outStr, stdout, t, errMsg, false)
+	}
+	if tt.ExitCode != exitCode {
+		t.Errorf("Test %s exited with incorrect error code! Expected: %d, Actual: %d", tt.Name, tt.ExitCode, exitCode)
+	}
+}

--- a/structure_tests/types.go
+++ b/structure_tests/types.go
@@ -35,7 +35,8 @@ func (a *arrayFlags) Set(value string) error {
 }
 
 var schemaVersions map[string]VersionHolder = map[string]VersionHolder{
-	"1.0.0": new(VersionHolderv1),
+	"1.0.0": new(VersionHolderv000),
+	"1.1.0": new(VersionHolderv100),
 }
 
 type SchemaVersion struct {
@@ -48,10 +49,15 @@ type VersionHolder interface {
 	New() StructureTest
 }
 
-type VersionHolderv1 struct{}
+type VersionHolderv000 struct{}
+type VersionHolderv100 struct{}
 
-func (v VersionHolderv1) New() StructureTest {
-	return new(StructureTestv1)
+func (v VersionHolderv000) New() StructureTest {
+	return new(StructureTestv000)
+}
+
+func (v VersionHolderv100) New() StructureTest {
+	return new(StructureTestv100)
 }
 
 type EnvVar struct {

--- a/structure_tests/types.go
+++ b/structure_tests/types.go
@@ -35,8 +35,8 @@ func (a *arrayFlags) Set(value string) error {
 }
 
 var schemaVersions map[string]VersionHolder = map[string]VersionHolder{
-	"1.0.0": new(VersionHolderv000),
-	"1.1.0": new(VersionHolderv100),
+	"1.0.0": new(VersionHolderv0),
+	"1.1.0": new(VersionHolderv1),
 }
 
 type SchemaVersion struct {
@@ -49,15 +49,15 @@ type VersionHolder interface {
 	New() StructureTest
 }
 
-type VersionHolderv000 struct{}
-type VersionHolderv100 struct{}
+type VersionHolderv0 struct{}
+type VersionHolderv1 struct{}
 
-func (v VersionHolderv000) New() StructureTest {
-	return new(StructureTestv000)
+func (v VersionHolderv0) New() StructureTest {
+	return new(StructureTestv0)
 }
 
-func (v VersionHolderv100) New() StructureTest {
-	return new(StructureTestv100)
+func (v VersionHolderv1) New() StructureTest {
+	return new(StructureTestv1)
 }
 
 type EnvVar struct {

--- a/structure_tests/utils.go
+++ b/structure_tests/utils.go
@@ -1,0 +1,137 @@
+// Copyright 2017 Google Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// given a list of environment variable key/value pairs, set these in the current environment.
+// also, keep track of the previous values of these vars to reset after test execution.
+func SetEnvVars(t *testing.T, vars []EnvVar) []EnvVar {
+	var originalVars []EnvVar
+	for _, env_var := range vars {
+		originalVars = append(originalVars, EnvVar{env_var.Key, os.Getenv(env_var.Key)})
+		if err := os.Setenv(env_var.Key, os.ExpandEnv(env_var.Value)); err != nil {
+			t.Fatalf("error setting env var: %s", err)
+		}
+	}
+	return originalVars
+}
+
+func ResetEnvVars(t *testing.T, vars []EnvVar) {
+	for _, env_var := range vars {
+		var err error
+		if env_var.Value == "" {
+			// if the previous value was empty string, the variable did not
+			// exist in the environment; unset it
+			err = os.Unsetenv(env_var.Key)
+		} else {
+			// otherwise, set it back to its previous value
+			err = os.Setenv(env_var.Key, env_var.Value)
+		}
+		if err != nil {
+			t.Fatalf("error resetting env var: %s", err)
+		}
+	}
+}
+
+func compileAndRunRegex(regex string, base string, t *testing.T, err string, shouldMatch bool) {
+	r, rErr := regexp.Compile(regex)
+	if rErr != nil {
+		t.Errorf("Error compiling regex %s : %s", regex, rErr.Error())
+		return
+	}
+	if shouldMatch != r.MatchString(base) {
+		t.Errorf(err)
+	}
+}
+
+// given an array of command parts, construct a full command and execute it against the
+// current environment. a list of environment variables can be passed to be set in the
+// environment before the command is executed. additionally, a boolean flag is passed
+// to specify whether or not we care about the output of the command.
+func ProcessCommand(t *testing.T, envVars []EnvVar, fullCommand []string,
+	shellMode bool, checkOutput bool) (string, string, int) {
+	var cmd *exec.Cmd
+	if len(fullCommand) == 0 {
+		t.Logf("empty command provided: skipping...")
+		return "", "", -1
+	}
+	var command string
+	var flags []string
+	if shellMode {
+		command = "/bin/sh"
+		flags = []string{"-c", strings.Join(fullCommand, " ")}
+	} else {
+		command = fullCommand[0]
+		flags = fullCommand[1:]
+	}
+	originalVars := SetEnvVars(t, envVars)
+	defer ResetEnvVars(t, originalVars)
+	if len(flags) > 0 {
+		cmd = exec.Command(command, flags...)
+	} else {
+		cmd = exec.Command(command)
+	}
+
+	if checkOutput {
+		t.Logf("Executing: %s", cmd.Args)
+	} else {
+		t.Logf("Executing setup/teardown: %s", cmd.Args)
+	}
+
+	var outbuf, errbuf bytes.Buffer
+
+	cmd.Stdout = &outbuf
+	cmd.Stderr = &errbuf
+
+	err := cmd.Run()
+	stdout := outbuf.String()
+	if stdout != "" {
+		t.Logf("stdout: %s", stdout)
+	}
+	stderr := errbuf.String()
+	if stderr != "" {
+		t.Logf("stderr: %s", stderr)
+	}
+	var exitCode int
+	if err != nil {
+		if checkOutput {
+			// The test might be designed to run a command that exits with an error.
+			t.Logf("Error running command: %s. Continuing.", err)
+		} else {
+			t.Fatalf("Error running setup/teardown command: %s.", err)
+		}
+		switch err := err.(type) {
+		default:
+			t.Errorf("Command failed to start! Unable to retrieve error info!")
+		case *exec.ExitError:
+			exitCode = err.Sys().(syscall.WaitStatus).ExitStatus()
+		case *exec.Error:
+			// Command started but failed to finish, so we can at least check the stderr
+			stderr = err.Error()
+		}
+	} else {
+		exitCode = cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+	}
+	return stdout, stderr, exitCode
+}


### PR DESCRIPTION
This adds a new schema version, v1.1.0, which splits the `command` argument in the Command Tests to `entrypoint` and `args`, as expected by k8s configs.

This also contains a bit of refactoring to reflect the version of each test component in the structure test config version.

Partially fixes #317 