### PR TITLE
Remove gcloud dependency from retagger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,4 @@ script:
  - ./.gofmt.sh
  - ./.buildifier.sh
  - bazel test reconciletags:reconciletags_test
- - bazel test reconciletags:reconciletags_e2e_test
  - bazel clean && bazel build //...

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ script:
  - flake8 .
  - ./.gofmt.sh
  - ./.buildifier.sh
- - bazel test reconciletags:reconciletags_test
  - bazel clean && bazel build //...
+ - bazel test reconciletags:reconciletags_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,6 @@ script:
  - flake8 .
  - ./.gofmt.sh
  - ./.buildifier.sh
- - python -m unittest discover -s reconciletags -p 'reconciletags_test.py'
+ - bazel test reconciletags:reconciletags_test
+ - bazel test reconciletags:reconciletags_e2e_test
  - bazel clean && bazel build //...

--- a/BUILD
+++ b/BUILD
@@ -9,6 +9,14 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
+py_library(
+    name = "reconciletags",
+    srcs = glob(["reconciletags/*.py"]),
+    deps = [
+        "@containerregistry",
+    ],
+)
+
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_prefix",

--- a/BUILD
+++ b/BUILD
@@ -9,14 +9,6 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-py_library(
-    name = "reconciletags",
-    srcs = glob(["reconciletags/*.py"]),
-    deps = [
-        "@containerregistry",
-    ],
-)
-
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_prefix",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,8 +32,15 @@ new_go_repository(
 
 git_repository(
     name = "io_bazel_rules_docker",
+    commit = "db1b348dfdf161a784bc1efc5a1020395572b996",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    tag = "v0.0.1",
+
+)
+
+git_repository(
+    name = "containerregistry",
+    commit = "b0278a1544238d03648861b6d9395414d4c958e5",
+    remote = "https://github.com/google/containerregistry",
 )
 
 load(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,3 +48,25 @@ load(
   "docker_repositories"
 )
 docker_repositories()
+
+new_http_archive(
+    name = "mock",
+    build_file_content = """
+# Rename mock.py to __init__.py
+genrule(
+    name = "rename",
+    srcs = ["mock.py"],
+    outs = ["__init__.py"],
+    cmd = "cat $< >$@",
+)
+py_library(
+   name = "mock",
+   srcs = [":__init__.py"],
+   visibility = ["//visibility:public"],
+)""",
+    sha256 = "b839dd2d9c117c701430c149956918a423a9863b48b09c90e30a6013e7d2f44f",
+    strip_prefix = "mock-1.0.1/",
+    type = "tar.gz",
+    url = "https://pypi.python.org/packages/source/m/mock/mock-1.0.1.tar.gz",
+)
+

--- a/reconciletags/BUILD
+++ b/reconciletags/BUILD
@@ -31,3 +31,15 @@ py_test(
     ],
 ) 
 
+py_test(
+    name = "reconciletags_e2e_test",
+    srcs = ["reconciletags_e2e_test.py",],
+    deps = [
+        "@containerregistry",
+        "@httplib2//:httplib2",
+    ],
+    data = [
+        "tiny_docker_image",
+    ],
+
+) 

--- a/reconciletags/BUILD
+++ b/reconciletags/BUILD
@@ -1,6 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 
-
 load("@subpar//:subpar.bzl", "par_binary")
 
 load(
@@ -23,11 +22,3 @@ py_binary(
     ],
 )
 
-py_test(
-    name = "reconciletags_test",
-    srcs = ["reconciletags_test.py"],
-    deps = [
-        "@containerregistry",
-        "@httplib2//:httplib2",
-    ],
-)

--- a/reconciletags/BUILD
+++ b/reconciletags/BUILD
@@ -1,21 +1,21 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@subpar//:subpar.bzl", "par_binary")
-
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_prefix",
 )
-
 load(
     "@io_bazel_rules_docker//docker:docker.bzl",
     "docker_push",
     "docker_build",
 )
 
-py_binary(
+par_binary(
     name = "reconciletags",
-    srcs = glob(["*.py"]),
+    srcs = ["reconciletags.py"],
+    main = "reconciletags.py",
+    visibility = ["//visibility:public"],
     deps = [
         "@containerregistry",
         "@httplib2//:httplib2",
@@ -28,14 +28,16 @@ py_test(
     deps = [
         "@containerregistry",
         "@httplib2//:httplib2",
+        "@mock",
     ],
 )
 
 py_test(
     name = "reconciletags_e2e_test",
-    srcs = ["reconciletags_e2e_test.py",],
+    srcs = ["reconciletags_e2e_test.py"],
     deps = [
         "@containerregistry",
         "@httplib2//:httplib2",
+        "@mock",
     ],
 )

--- a/reconciletags/BUILD
+++ b/reconciletags/BUILD
@@ -8,9 +8,9 @@ load(
 )
 
 load(
-     "@io_bazel_rules_docker//docker:docker.bzl",
-     "docker_push",
-     "docker_build",
+    "@io_bazel_rules_docker//docker:docker.bzl",
+    "docker_push",
+    "docker_build",
 )
 
 py_binary(
@@ -29,7 +29,7 @@ py_test(
         "@containerregistry",
         "@httplib2//:httplib2",
     ],
-) 
+)
 
 py_test(
     name = "reconciletags_e2e_test",
@@ -38,8 +38,4 @@ py_test(
         "@containerregistry",
         "@httplib2//:httplib2",
     ],
-    data = [
-        "tiny_docker_image",
-    ],
-
-) 
+)

--- a/reconciletags/BUILD
+++ b/reconciletags/BUILD
@@ -22,3 +22,12 @@ py_binary(
     ],
 )
 
+py_test(
+    name = "reconciletags_test",
+    srcs = ["reconciletags_test.py"],
+    deps = [
+        "@containerregistry",
+        "@httplib2//:httplib2",
+    ],
+) 
+

--- a/reconciletags/BUILD
+++ b/reconciletags/BUILD
@@ -1,0 +1,33 @@
+package(default_visibility = ["//visibility:public"])
+
+
+load("@subpar//:subpar.bzl", "par_binary")
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_prefix",
+)
+
+load(
+     "@io_bazel_rules_docker//docker:docker.bzl",
+     "docker_push",
+     "docker_build",
+)
+
+py_binary(
+    name = "reconciletags",
+    srcs = glob(["*.py"]),
+    deps = [
+        "@containerregistry",
+        "@httplib2//:httplib2",
+    ],
+)
+
+py_test(
+    name = "reconciletags_test",
+    srcs = ["reconciletags_test.py"],
+    deps = [
+        "@containerregistry",
+        "@httplib2//:httplib2",
+    ],
+)

--- a/reconciletags/reconciletags.py
+++ b/reconciletags/reconciletags.py
@@ -48,8 +48,8 @@ class TagReconciler:
                     with docker_session.Push(dest_name, creds, transport) as push:
                         push.upload(src_img)
                 else:
-                    logging.debug("Unable to tag {0} \
-                        as the image can't be found".format(digest))
+                    logging.debug("Unable to tag {0}"
+                        " as the image can't be found".format(digest))
         else:
             logging.debug("Would have tagged {0} with {1}".format(digest, tag))
 
@@ -66,8 +66,8 @@ class TagReconciler:
                 existing_tags = img.tags()
             else:
                 logging.debug(
-                    "Unable to get existing tags for {0} \
-                        as the image can't be found".format(full_digest))
+                    "Unable to get existing tags for {0}"
+                        " as the image can't be found".format(full_digest))
         return existing_tags
     
     def get_latest_digest(self, manifests):

--- a/reconciletags/reconciletags.py
+++ b/reconciletags/reconciletags.py
@@ -35,16 +35,6 @@ from containerregistry.transport import transport_pool
 from containerregistry.client import docker_name
 
 class TagReconciler:
-    def call(self, command, dry_run, fmt="json"):
-        command += " --format=" + fmt
-        if not dry_run:
-            logging.debug('Running {0}'.format(command))
-            output = subprocess.check_output([command], shell=True)
-            logging.debug(output)
-            return output
-        else:
-            logging.debug('Would have run {0}'.format(command))
-
     def add_tags(self, digest, tag, dry_run): 
         if not dry_run:
             src_name = docker_name.Digest(digest)
@@ -59,15 +49,6 @@ class TagReconciler:
                         push.upload(src_img)
         else:
             logging.debug("Would have tagged {0} with {1}".format(digest, tag))
-
-    # This turns a list of lists into one flat list of tags
-    def flatten_tags_list(self, list_of_lists):
-        flat_tags_list = []
-        for sublist in list_of_lists:
-            for tag in sublist:
-                if tag:
-                    flat_tags_list.append(tag)
-        return flat_tags_list
     
     def get_existing_tags(self, full_repo, digest):
         full_digest = full_repo + '@sha256:' + digest
@@ -89,7 +70,7 @@ class TagReconciler:
                 return digest
     
     def reconcile_tags(self, data, dry_run):
-        self.call('gcloud config list', False)
+
         for project in data['projects']:
             default_registry = project['base_registry']
 

--- a/reconciletags/reconciletags.py
+++ b/reconciletags/reconciletags.py
@@ -31,8 +31,8 @@ from containerregistry.client.v2_2 import docker_image
 from containerregistry.client.v2_2 import docker_image_list
 from containerregistry.client.v2_2 import docker_session
 from containerregistry.client import docker_creds
-from containerregistry.transport import transport_pool
 from containerregistry.client import docker_name
+from containerregistry.transport import transport_pool
 
 class TagReconciler:
     def add_tags(self, digest, tag, dry_run): 
@@ -64,7 +64,7 @@ class TagReconciler:
         
         return existing_tags
     
-    def get_latest_digest(self, full_repo, manifests):
+    def get_latest_digest(self, manifests):
         for digest in manifests:
             if "latest" in manifests[digest]['tag']:
                 return digest
@@ -83,7 +83,6 @@ class TagReconciler:
                 for image in project['images']:
                     full_digest = full_repo + '@sha256:' + image['digest']
                     full_tag = full_repo + ':' + image['tag']
-                    existing_tags = []
 
                     name = docker_name.Digest(full_digest)
                     creds = docker_creds.DefaultKeychain.Resolve(name)
@@ -93,10 +92,9 @@ class TagReconciler:
                         if img.exists():
                             existing_tags = img.tags()
                             logging.debug("Existing Tags: {0}".format(existing_tags))
-                            logging.debug(full_repo)
 
                             manifests = img.manifests()
-                            latest = self.get_latest_digest(full_repo, manifests)
+                            latest = self.get_latest_digest(manifests)
                             
                             # Don't retag latest if it's already latest
                             if latest:

--- a/reconciletags/reconciletags.py
+++ b/reconciletags/reconciletags.py
@@ -114,6 +114,9 @@ class TagReconciler:
                     logging.debug('Existing Tags: {0}'.format(existing_tags))
 
                     name = docker_name.Digest(default_digest)
+                    creds = docker_creds.DefaultKeychain.Resolve(name)
+                    transport = transport_pool.Http(httplib2.Http)
+
                     with docker_image.FromRegistry(name, creds, transport) as img:
                         if img.exists():
                             full_digest = full_repo + '@sha256:' +image['digest']

--- a/reconciletags/reconciletags_e2e_test.py
+++ b/reconciletags/reconciletags_e2e_test.py
@@ -23,7 +23,7 @@ import unittest
 class ReconciletagsE2eTest(unittest.TestCase):
 
     _FILE_NAME = 'e2e_test.json'
-    _DIR = 'tiny_docker_image/'
+    _DIR = 'reconciletags/tiny_docker_image/'
     _REPO = 'gcr.io/gcp-runtimes/reconciler-e2etest'
     _TAG = 'initial'
     _TEST_JSON = {

--- a/reconciletags/reconciletags_test.py
+++ b/reconciletags/reconciletags_test.py
@@ -45,16 +45,7 @@ _LIST_RESP = """
 ]
 """
 
-_EXISTING_TAGS = 'Existing Tags: {0}'.format([_TAG1])
-_TAGGING_DRY_RUN = 'Would have tagged {0} with {1}'.format(
-    _FULL_REPO+'@sha256:'+_DIGEST1, _FULL_REPO+":"+_TAG1)
-
-
 class ReconcileTagsTest(unittest.TestCase):
-
-    def _tagging(self, digest, tag):
-        return 'Tagging {0} with {1}'.format(
-            _FULL_REPO+'@sha256:'+digest, _FULL_REPO+':'+tag)
 
     def setUp(self):
         self.r = reconciletags.TagReconciler()
@@ -75,17 +66,10 @@ class ReconcileTagsTest(unittest.TestCase):
         mock_from_registry.return_value = mock_img
         mock_push.return_value = docker_session.Push()
 
-        with mock.patch('reconciletags.logging.debug') as mock_output:
+        self.r.reconcile_tags(self.data, False)
 
-            self.r.reconcile_tags(self.data, False)
-            logging_debug_output = [call[1][0] for
-                                    call in mock_output.mock_calls]
-
-            assert mock_from_registry.called
-            assert mock_push.called
-
-            self.assertIn(self._tagging(_DIGEST1, _TAG1), logging_debug_output)
-            self.assertIn(_EXISTING_TAGS, logging_debug_output)
+        assert mock_from_registry.called
+        assert mock_push.called
 
     @patch('containerregistry.client.v2_2.docker_session.Push')
     @patch('containerregistry.client.v2_2.docker_image.FromRegistry')
@@ -93,18 +77,10 @@ class ReconcileTagsTest(unittest.TestCase):
         mock_from_registry.return_value = docker_image.FromRegistry()
         mock_push.return_value = docker_session.Push()
 
-        with mock.patch('reconciletags.logging.debug') as mock_output:
+        self.r.reconcile_tags(self.data, True)
 
-            self.r.reconcile_tags(self.data, True)
-            logging_debug_output = [call[1][0] for
-                                    call in mock_output.mock_calls]
-
-            assert mock_from_registry.called
-            assert mock_push.called
-
-            self.assertNotIn(self._tagging(_DIGEST1, _TAG1),
-                             logging_debug_output)
-            self.assertIn(_TAGGING_DRY_RUN, logging_debug_output)
+        assert mock_from_registry.called
+        assert mock_push.called
 
     @patch('containerregistry.client.v2_2.docker_image.FromRegistry')
     def test_get_existing_tags(self, mock_from_registry):
@@ -127,17 +103,11 @@ class ReconcileTagsTest(unittest.TestCase):
         mock_from_registry.return_value = docker_image.FromRegistry()
         mock_push.return_value = docker_session.Push()
 
-        with mock.patch('reconciletags.logging.debug') as mock_output:
+        self.r.add_tags(_FULL_REPO+'@sha256:'+_DIGEST2,
+                        _FULL_REPO+':'+_TAG2, False)
 
-            self.r.add_tags(_FULL_REPO+'@sha256:'+_DIGEST2,
-                            _FULL_REPO+':'+_TAG2, False)
-            logging_debug_output = [call[1][0] for
-                                    call in mock_output.mock_calls]
-
-            assert mock_from_registry.called
-            assert mock_push.called
-
-            self.assertIn(self._tagging(_DIGEST2, _TAG2), logging_debug_output)
+        assert mock_from_registry.called
+        assert mock_push.called
 
 
 if __name__ == '__main__':

--- a/reconciletags/reconciletags_test.py
+++ b/reconciletags/reconciletags_test.py
@@ -34,7 +34,8 @@ _TAG2 = 'tag2'
 _LIST_RESP = """
 [
   {
-    "digest": "0000000000000000000000000000000000000000000000000000000000000000",
+    "digest": 
+        "0000000000000000000000000000000000000000000000000000000000000000",
     "tags": [
       "tag1"
     ],
@@ -77,7 +78,8 @@ class ReconcileTagsTest(unittest.TestCase):
         with mock.patch('reconciletags.logging.debug') as mock_output:
 
             self.r.reconcile_tags(self.data, False)
-            logging_debug_output = [call[1][0] for call in mock_output.mock_calls]
+            logging_debug_output = [call[1][0] for 
+                call in mock_output.mock_calls]
 
             assert mock_from_registry.called
             assert mock_push.called
@@ -94,12 +96,14 @@ class ReconcileTagsTest(unittest.TestCase):
         with mock.patch('reconciletags.logging.debug') as mock_output:
 
             self.r.reconcile_tags(self.data, True)
-            logging_debug_output = [call[1][0] for call in mock_output.mock_calls]
+            logging_debug_output = [call[1][0] for 
+                call in mock_output.mock_calls]
 
             assert mock_from_registry.called
             assert mock_push.called
 
-            self.assertNotIn(self._tagging(_DIGEST1, _TAG1), logging_debug_output)
+            self.assertNotIn(self._tagging(_DIGEST1, _TAG1), 
+                logging_debug_output)
             self.assertIn(_TAGGING_DRY_RUN, logging_debug_output)
 
     @patch('containerregistry.client.v2_2.docker_image.FromRegistry')
@@ -113,7 +117,7 @@ class ReconcileTagsTest(unittest.TestCase):
         mock_from_registry.return_value = mock_img
 
         existing_tags = self.r.get_existing_tags(_FULL_REPO, _DIGEST1)
-        
+
         assert mock_from_registry.called
         self.assertEqual([_TAG1], existing_tags)
 
@@ -126,13 +130,14 @@ class ReconcileTagsTest(unittest.TestCase):
         with mock.patch('reconciletags.logging.debug') as mock_output:
 
             self.r.add_tags(_FULL_REPO+'@sha256:'+_DIGEST2,
-                            _FULL_REPO+':'+_TAG2, False)           
-            logging_debug_output = [call[1][0] for call in mock_output.mock_calls]
+                            _FULL_REPO+':'+_TAG2, False)       
+            logging_debug_output = [call[1][0] for 
+                call in mock_output.mock_calls]
 
             assert mock_from_registry.called
             assert mock_push.called
 
-            self.assertIn(self._tagging(_DIGEST2, _TAG2), logging_debug_output) 
+            self.assertIn(self._tagging(_DIGEST2, _TAG2), logging_debug_output)
 
 
 if __name__ == '__main__':

--- a/reconciletags/reconciletags_test.py
+++ b/reconciletags/reconciletags_test.py
@@ -45,6 +45,7 @@ _LIST_RESP = """
 ]
 """
 
+
 class ReconcileTagsTest(unittest.TestCase):
 
     def setUp(self):

--- a/reconciletags/reconciletags_test.py
+++ b/reconciletags/reconciletags_test.py
@@ -17,11 +17,11 @@
 Unit tests for reconcile-tags.py.
 """
 import unittest
+from containerregistry.client.v2_2 import docker_image
+from containerregistry.client.v2_2 import docker_session
 import mock
 from mock import patch
 import reconciletags
-from containerregistry.client.v2_2 import docker_image
-from containerregistry.client.v2_2 import docker_session
 
 _REGISTRY = 'gcr.io'
 _REPO = 'foobar/baz'
@@ -44,15 +44,16 @@ _LIST_RESP = """
 ]
 """
 
-_EXISTING_TAGS = "Existing Tags: {0}".format([_TAG1])
-_TAGGING_DRY_RUN = "Would have tagged {0} with {1}".format(
-                _FULL_REPO+'@sha256:'+_DIGEST1, _FULL_REPO+":"+_TAG1)
+_EXISTING_TAGS = 'Existing Tags: {0}'.format([_TAG1])
+_TAGGING_DRY_RUN = 'Would have tagged {0} with {1}'.format(
+    _FULL_REPO+'@sha256:'+_DIGEST1, _FULL_REPO+":"+_TAG1)
+
 
 class ReconcileTagsTest(unittest.TestCase):
 
     def _tagging(self, digest, tag):
-        return "Tagging {0} with {1}".format(
-                _FULL_REPO+'@sha256:'+digest, _FULL_REPO+":"+tag)
+        return 'Tagging {0} with {1}'.format(
+            _FULL_REPO+'@sha256:'+digest, _FULL_REPO+':'+tag)
 
     def setUp(self):
         self.r = reconciletags.TagReconciler()
@@ -61,7 +62,7 @@ class ReconcileTagsTest(unittest.TestCase):
                        'additional_registries': [],
                        'repository': _REPO,
                        'images': [{'digest': _DIGEST1, 'tag': _TAG1}]}]}
-    
+
     @patch('containerregistry.client.v2_2.docker_session.Push')
     @patch('containerregistry.client.v2_2.docker_image.FromRegistry')
     def test_reconcile_tags(self, mock_from_registry, mock_push):
@@ -73,36 +74,34 @@ class ReconcileTagsTest(unittest.TestCase):
         mock_from_registry.return_value = mock_img
         mock_push.return_value = docker_session.Push()
 
-        
         with mock.patch('reconciletags.logging.debug') as mock_output:
 
             self.r.reconcile_tags(self.data, False)
-            logging_debug_ouput = [call[1][0] for call in mock_output.mock_calls]
+            logging_debug_output = [call[1][0] for call in mock_output.mock_calls]
 
             assert mock_from_registry.called
             assert mock_push.called
 
-            self.assertIn(self._tagging(_DIGEST1, _TAG1), logging_debug_ouput)
-            self.assertIn(_EXISTING_TAGS, logging_debug_ouput)
-    
+            self.assertIn(self._tagging(_DIGEST1, _TAG1), logging_debug_output)
+            self.assertIn(_EXISTING_TAGS, logging_debug_output)
+
     @patch('containerregistry.client.v2_2.docker_session.Push')
     @patch('containerregistry.client.v2_2.docker_image.FromRegistry')
     def test_dry_run(self, mock_from_registry, mock_push):
         mock_from_registry.return_value = docker_image.FromRegistry()
         mock_push.return_value = docker_session.Push()
 
-        
         with mock.patch('reconciletags.logging.debug') as mock_output:
 
             self.r.reconcile_tags(self.data, True)
-            logging_debug_ouput = [call[1][0] for call in mock_output.mock_calls]
+            logging_debug_output = [call[1][0] for call in mock_output.mock_calls]
 
             assert mock_from_registry.called
             assert mock_push.called
 
-            self.assertNotIn(self._tagging(_DIGEST1, _TAG1), logging_debug_ouput)
-            self.assertIn(_TAGGING_DRY_RUN, logging_debug_ouput)
-    
+            self.assertNotIn(self._tagging(_DIGEST1, _TAG1), logging_debug_output)
+            self.assertIn(_TAGGING_DRY_RUN, logging_debug_output)
+
     @patch('containerregistry.client.v2_2.docker_image.FromRegistry')
     def test_get_existing_tags(self, mock_from_registry):
 
@@ -124,18 +123,17 @@ class ReconcileTagsTest(unittest.TestCase):
         mock_from_registry.return_value = docker_image.FromRegistry()
         mock_push.return_value = docker_session.Push()
 
-        
         with mock.patch('reconciletags.logging.debug') as mock_output:
 
             self.r.add_tags(_FULL_REPO+'@sha256:'+_DIGEST2,
                             _FULL_REPO+':'+_TAG2, False)           
-            logging_debug_ouput = [call[1][0] for call in mock_output.mock_calls]
+            logging_debug_output = [call[1][0] for call in mock_output.mock_calls]
 
             assert mock_from_registry.called
             assert mock_push.called
-            
-            self.assertIn(self._tagging(_DIGEST2, _TAG2), logging_debug_ouput) 
-    
+
+            self.assertIn(self._tagging(_DIGEST2, _TAG2), logging_debug_output) 
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/reconciletags/reconciletags_test.py
+++ b/reconciletags/reconciletags_test.py
@@ -34,7 +34,7 @@ _TAG2 = 'tag2'
 _LIST_RESP = """
 [
   {
-    "digest": 
+    "digest":
         "0000000000000000000000000000000000000000000000000000000000000000",
     "tags": [
       "tag1"
@@ -78,8 +78,8 @@ class ReconcileTagsTest(unittest.TestCase):
         with mock.patch('reconciletags.logging.debug') as mock_output:
 
             self.r.reconcile_tags(self.data, False)
-            logging_debug_output = [call[1][0] for 
-                call in mock_output.mock_calls]
+            logging_debug_output = [call[1][0] for
+                                    call in mock_output.mock_calls]
 
             assert mock_from_registry.called
             assert mock_push.called
@@ -96,14 +96,14 @@ class ReconcileTagsTest(unittest.TestCase):
         with mock.patch('reconciletags.logging.debug') as mock_output:
 
             self.r.reconcile_tags(self.data, True)
-            logging_debug_output = [call[1][0] for 
-                call in mock_output.mock_calls]
+            logging_debug_output = [call[1][0] for
+                                    call in mock_output.mock_calls]
 
             assert mock_from_registry.called
             assert mock_push.called
 
-            self.assertNotIn(self._tagging(_DIGEST1, _TAG1), 
-                logging_debug_output)
+            self.assertNotIn(self._tagging(_DIGEST1, _TAG1),
+                             logging_debug_output)
             self.assertIn(_TAGGING_DRY_RUN, logging_debug_output)
 
     @patch('containerregistry.client.v2_2.docker_image.FromRegistry')
@@ -130,9 +130,9 @@ class ReconcileTagsTest(unittest.TestCase):
         with mock.patch('reconciletags.logging.debug') as mock_output:
 
             self.r.add_tags(_FULL_REPO+'@sha256:'+_DIGEST2,
-                            _FULL_REPO+':'+_TAG2, False)       
-            logging_debug_output = [call[1][0] for 
-                call in mock_output.mock_calls]
+                            _FULL_REPO+':'+_TAG2, False)
+            logging_debug_output = [call[1][0] for
+                                    call in mock_output.mock_calls]
 
             assert mock_from_registry.called
             assert mock_push.called


### PR DESCRIPTION
This PR updates the WORKSPACE file and creates a BUILD file so that we can use bazel to pull in the containerregistry library, which is used to remove the google3 dependency in retagger (which is 
reconciletags.py)