### PR TITLE
Update dependency versions

### DIFF
--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-google-cloud-bigquery==0.22.0
-google-cloud-logging==0.22.0
-google-cloud-monitoring==0.22.0
-google-cloud-error-reporting==0.22.0
+google-cloud-bigquery==0.27.0
+google-cloud-logging==1.3.0
+google-cloud-monitoring==0.27.0
+google-cloud-error-reporting==0.27.0
 retrying==1.3.3


### PR DESCRIPTION
Using the old versions caused the integration test build failure.