### PR TITLE
Make the context manager functions consistenly non-abstract.

### DIFF
--- a/ftl/common/builder.py
+++ b/ftl/common/builder.py
@@ -49,14 +49,11 @@ class Base(object):
           a raw string of the layer's .tar.gz
         """
 
-    # __enter__ and __exit__ allow use as a context manager.
-    @abc.abstractmethod
     def __enter__(self):
         """Initialize the builder."""
 
     def __exit__(self, unused_type, unused_value, unused_traceback):
         """Cleanup after the builder."""
-        pass
 
 
 class JustApp(Base):
@@ -65,10 +62,6 @@ class JustApp(Base):
     """
     def __init__(self, ctx):
         super(JustApp, self).__init__(ctx)
-
-    def __enter__(self):
-        """Override."""
-        return self
 
     def CreatePackageBase(self, base_image, cache):
         """Override."""

--- a/ftl/common/cache.py
+++ b/ftl/common/cache.py
@@ -35,7 +35,6 @@ class Base(object):
 
     def __exit__(self, unused_type, unused_value, unused_traceback):
         """Cleanup the context."""
-        pass
 
     @abc.abstractmethod
     def Get(self, base_image, namespace, checksum):
@@ -73,9 +72,6 @@ class Registry(Base):
         self._transport = transport
         self._threads = threads
         self._mount = mount or []
-
-    def __enter__(self):
-        return self
 
     def _tag(self, base_image, namespace, checksum):
         fingerprint = '%s %s' % (base_image.digest(), checksum)

--- a/ftl/common/context.py
+++ b/ftl/common/context.py
@@ -25,14 +25,11 @@ class Base(object):
     It provides methods used by builders for accessing app files.
     """
     # __enter__ and __exit__ allow use as a context manager.
-    @abc.abstractmethod
     def __enter__(self):
         """Initialize the context."""
 
-    @abc.abstractmethod
     def __exit__(self, unused_type, unused_value, unused_traceback):
         """Cleanup the context."""
-        pass
 
     @abc.abstractmethod
     def Contains(self, relative_path):
@@ -64,12 +61,6 @@ class Workspace(Base):
         super(Workspace, self).__init__()
         self._directory = directory
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, unused_type, unused_value, unused_traceback):
-        return self
-
     def Contains(self, relative_path):
         """Override."""
         fqpath = os.path.join(self._directory, relative_path)
@@ -95,12 +86,6 @@ class Memory(Base):
 
     def __init__(self):
         self._files = {}
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, unused_type, unused_value, unused_traceback):
-        return self
 
     def AddFile(self, filename, contents):
         self._files[filename] = contents


### PR DESCRIPTION
They can still be overridden, but don't need to be.

cc @mattmoor