### PR TITLE
Bug fix in retagger

### DIFF
--- a/reconciletags/reconciletags.py
+++ b/reconciletags/reconciletags.py
@@ -140,7 +140,7 @@ class TagReconciler:
                         for registry in registries:
                             full_repo = os.path.join(registry,
                                                      project['repository'])
-                            full_digest = full_repo + '@sha256:' + digest
+                            full_digest = default_repo + '@sha256:' + digest
                             full_tag = full_repo + ':' + image['tag']
                             self.add_tags(full_digest, full_tag, dry_run)
 


### PR DESCRIPTION
Fixes a bug in the retagger which prevented an image in the base registry from being copied into any additional registries