### PR TITLE
disable cgo when building structure tests in bazel

### DIFF
--- a/vendor/github.com/docker/docker/pkg/mount/BUILD.bazel
+++ b/vendor/github.com/docker/docker/pkg/mount/BUILD.bazel
@@ -21,7 +21,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
-    cgo = True,
+    cgo = False,
     importpath = "github.com/docker/docker/pkg/mount",
     visibility = ["//visibility:public"],
     deps = select({

--- a/vendor/github.com/docker/docker/pkg/system/BUILD.bazel
+++ b/vendor/github.com/docker/docker/pkg/system/BUILD.bazel
@@ -49,7 +49,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
-    cgo = True,
+    cgo = False,
     importpath = "github.com/docker/docker/pkg/system",
     visibility = ["//visibility:public"],
     deps = [

--- a/vendor/github.com/docker/docker/pkg/term/BUILD.bazel
+++ b/vendor/github.com/docker/docker/pkg/term/BUILD.bazel
@@ -20,7 +20,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
-    cgo = True,
+    cgo = False,
     importpath = "github.com/docker/docker/pkg/term",
     visibility = ["//visibility:public"],
     deps = [

--- a/vendor/github.com/opencontainers/runc/libcontainer/system/BUILD.bazel
+++ b/vendor/github.com/opencontainers/runc/libcontainer/system/BUILD.bazel
@@ -17,7 +17,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
-    cgo = True,
+    cgo = False,
     importpath = "github.com/opencontainers/runc/libcontainer/system",
     visibility = ["//visibility:public"],
     deps = select({

--- a/vendor/golang.org/x/sys/unix/BUILD.bazel
+++ b/vendor/golang.org/x/sys/unix/BUILD.bazel
@@ -56,7 +56,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
-    cgo = True,
+    cgo = False,
     importpath = "golang.org/x/sys/unix",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
These changes were made manually. Not sure if there's a way to autogenerate them.

cc @dlorenc 