### PR TITLE
add cloudbuild for structure tests

### DIFF
--- a/structure_test_cloudbuild.yaml
+++ b/structure_test_cloudbuild.yaml
@@ -1,0 +1,7 @@
+steps:
+#Build the binary with bazel
+  - name:  'gcr.io/cloud-builders/bazel'
+    args: ['build', 'structure_tests:go_default_test']
+#Copy par files into commit SHA bucket
+  - name: 'gcr.io/cloud-builders/gsutil'
+    args: ['cp', 'bazel-bin/structure_tests/go_default_test', 'gs://gcp-container-tools/structure-test/$COMMIT_SHA/']


### PR DESCRIPTION
This will be run through a build trigger, so that every commit will be built and uploaded to GCS in a folder referenced by commit SHA. We'll have a separate release job for copying selected artifacts into release buckets.

Also planning on updating this build config if/when we update the bazel job to use the `go_build` rule correctly.