### PR TITLE
Add --no-cache to npm install.

### DIFF
--- a/ftl/node/builder.py
+++ b/ftl/node/builder.py
@@ -68,7 +68,7 @@ class Node(builder.JustApp):
             f.write(self._ctx.GetFile(descriptor))
 
         tar_path = tempfile.mktemp()
-        subprocess.check_call(['npm', 'install'], cwd=app_dir)
+        subprocess.check_call(['npm', 'install', '--no-cache'], cwd=app_dir)
         subprocess.check_call(['tar', '-C', tmp, '-cf', tar_path, '.'])
 
         # We need the sha of the unzipped and zipped tarball.


### PR DESCRIPTION
The test was failing on my machine because npm tries to write to
$HOME/.npm as a cache, and didn't have permissions. This is unlikely
to benefit anything in a container, and will just slow down installs.

cc @aaron-prindle 