### PR TITLE
add bazel rules to build and push structure test container image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,7 @@ go_proto_repositories()
 
 git_repository(
     name = "io_bazel_rules_docker",
-    commit = "65df68f4f64e9c59eb571290eb86bf07766393b6",
+    commit = "8bbe2a8abd382641e65ff7127a3700a8530f02ce",
     remote = "https://github.com/bazelbuild/rules_docker.git",
 )
 
@@ -35,6 +35,13 @@ load(
 )
 
 docker_repositories()
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "repositories"
+)
+
+repositories()
 
 new_http_archive(
     name = "mock",
@@ -75,4 +82,11 @@ docker_pull(
     digest = "sha256:f98878fe17ac9474f5a4beb9f692272f698a9ce2dc1e6297d449b2003cfec3e9",
     registry = "gcr.io",
     repository = "google-appengine/nodejs",
+)
+
+docker_pull(
+    name = "distroless_base",
+    digest = "sha256:4a8979a768c3ef8d0a8ed8d0af43dc5920be45a51749a9c611d178240f136eb4",
+    registry = "gcr.io",
+    repository = "distroless/base"
 )

--- a/ftl/BUILD
+++ b/ftl/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@io_bazel_rules_docker//docker/contrib/python:image.bzl",
+    "@io_bazel_rules_docker//python:image.bzl",
     "py_image",
 )
 load(

--- a/reconciletags/BUILD
+++ b/reconciletags/BUILD
@@ -10,7 +10,7 @@ load(
     "docker_push",
     "docker_build",
 )
-load("@io_bazel_rules_docker//docker/contrib/python:image.bzl", "py_image")
+load("@io_bazel_rules_docker//python:image.bzl", "py_image")
 
 par_binary(
     name = "reconciletags",

--- a/structure_tests/BUILD.bazel
+++ b/structure_tests/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
 
 licenses(["notice"])
 
@@ -35,4 +36,22 @@ go_test(
         "//structure_tests/drivers:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
     ],
+    testonly = False,
+)
+
+container_image(
+    name = "structure_test_image",
+    base = "@distroless_base//image",
+    files = [":go_default_test"],
+    cmd = ["/go_default_test"],
+    testonly = False,
+)
+
+container_push(
+    name = "push_structure_test",
+    image = ":structure_test_image",
+    format = "Docker",
+    registry = "gcr.io",
+    repository = "gcp-runtimes/structure-test",
+    tag = "bazel",
 )

--- a/structure_tests/BUILD.bazel
+++ b/structure_tests/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 licenses(["notice"])
 
@@ -45,13 +45,4 @@ container_image(
     base = "@distroless_base//image",
     cmd = ["/go_default_test"],
     files = [":go_default_test"],
-)
-
-container_push(
-    name = "push_structure_test",
-    format = "Docker",
-    image = ":structure_test_image",
-    registry = "gcr.io",
-    repository = "gcp-runtimes/structure-test",
-    tag = "bazel",
 )

--- a/structure_tests/BUILD.bazel
+++ b/structure_tests/BUILD.bazel
@@ -29,6 +29,7 @@ go_binary(
 
 go_test(
     name = "go_default_test",
+    testonly = False,
     srcs = ["structure_test.go"],
     importpath = "github.com/GoogleCloudPlatform/runtimes-common/structure_tests",
     library = ":go_default_library",
@@ -36,21 +37,20 @@ go_test(
         "//structure_tests/drivers:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
     ],
-    testonly = False,
 )
 
 container_image(
     name = "structure_test_image",
-    base = "@distroless_base//image",
-    files = [":go_default_test"],
-    cmd = ["/go_default_test"],
     testonly = False,
+    base = "@distroless_base//image",
+    cmd = ["/go_default_test"],
+    files = [":go_default_test"],
 )
 
 container_push(
     name = "push_structure_test",
-    image = ":structure_test_image",
     format = "Docker",
+    image = ":structure_test_image",
     registry = "gcr.io",
     repository = "gcp-runtimes/structure-test",
     tag = "bazel",


### PR DESCRIPTION
I got this to work by running 

```
gcloud components install docker-credential-gcr \
&& docker-credential-gcr configure-docker \
&& bazel run :push_structure_test
```

Might be worth writing a small wrapper script that generates a new bazel build file so we can template in a Docker tag: currently this is publishing to `gcr.io/gcp-runtimes/structure-test:bazel`.

Note this will only work on Linux.

cc @dlorenc 