### PR TITLE
Update ftl integration tests to use bazel run

### DIFF
--- a/ftl/BUILD
+++ b/ftl/BUILD
@@ -83,15 +83,15 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 pkg_tar(
     name = "default_creds",
     srcs = [":config.json"],
-    package_dir = "/root/.docker",
     mode = "0600",
+    package_dir = "/root/.docker",
 )
 
 pkg_tar(
     name = "cred_helper",
     srcs = ["@docker_credential_gcr//:docker-credential-gcr"],
-    package_dir = "/usr/local/bin",
     mode = "0555",
+    package_dir = "/usr/local/bin",
 )
 
 # The node base image sets a default CMD, which causes issues if you run our image with no CMD.

--- a/ftl/ftl_node_integration_tests.yaml
+++ b/ftl/ftl_node_integration_tests.yaml
@@ -1,7 +1,7 @@
 steps:
 #Build node ftl image with bazel
   - name:  'gcr.io/cloud-builders/bazel'
-    args: ['run', '//ftl:node_builder_image.tar']
+    args: ['run', '--', '//ftl:node_builder_image', '--image']
 #Pull structure tests image
   - name:  'gcr.io/cloud-builders/docker'
     args: ['pull', 'gcr.io/gcp-runtimes/structure-test:6195641f5a5a14c63c7945262066270842150ddb']

--- a/ftl/ftl_node_integration_tests.yaml
+++ b/ftl/ftl_node_integration_tests.yaml
@@ -1,7 +1,7 @@
 steps:
 #Build node ftl image with bazel
   - name:  'gcr.io/cloud-builders/bazel'
-    args: ['run', '--', '//ftl:node_builder_image', '--image']
+    args: ['run','//ftl:node_builder_image', '--', '--norun']
 #Pull structure tests image
   - name:  'gcr.io/cloud-builders/docker'
     args: ['pull', 'gcr.io/gcp-runtimes/structure-test:6195641f5a5a14c63c7945262066270842150ddb']

--- a/ftl/node/main.py
+++ b/ftl/node/main.py
@@ -56,6 +56,11 @@ parser.add_argument(
     help='The path where the application data sits.')
 
 parser.add_argument(
+    '--image',
+    action='store_true',
+    help='Use this flag to build the node builder image with bazel run')
+
+parser.add_argument(
     "-v",
     "--verbosity",
     default="NOTSET",
@@ -66,6 +71,10 @@ parser.add_argument(
 
 def main(args):
     args = parser.parse_args(args)
+    
+    if args.image:
+        return
+
     logging.getLogger().setLevel(_LEVEL_MAP[args.verbosity])
 
     transport = transport_pool.Http(httplib2.Http, size=_THREADS)

--- a/ftl/node/main.py
+++ b/ftl/node/main.py
@@ -56,11 +56,6 @@ parser.add_argument(
     help='The path where the application data sits.')
 
 parser.add_argument(
-    '--image',
-    action='store_true',
-    help='Use this flag to build the node builder image with bazel run')
-
-parser.add_argument(
     "-v",
     "--verbosity",
     default="NOTSET",
@@ -71,10 +66,6 @@ parser.add_argument(
 
 def main(args):
     args = parser.parse_args(args)
-    
-    if args.image:
-        return
-
     logging.getLogger().setLevel(_LEVEL_MAP[args.verbosity])
 
     transport = transport_pool.Http(httplib2.Http, size=_THREADS)

--- a/reconciletags/BUILD
+++ b/reconciletags/BUILD
@@ -94,15 +94,15 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 pkg_tar(
     name = "default_creds",
     srcs = [":config.json"],
-    package_dir = "/root/.docker",
     mode = "0600",
+    package_dir = "/root/.docker",
 )
 
 pkg_tar(
     name = "cred_helper",
     srcs = ["@docker_credential_gcr//:docker-credential-gcr"],
-    package_dir = "/usr/local/bin",
     mode = "0555",
+    package_dir = "/usr/local/bin",
 )
 
 docker_build(


### PR DESCRIPTION
Added --image flag so that bazel run can build the image without errors, so that it can be used as a build step in the ftl integration tests.

#413 