### PR TITLE
Switch the mock_registry test to use a smaller image.

### DIFF
--- a/hack/kokoro-test.sh
+++ b/hack/kokoro-test.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -ex
 
+# shellcheck source=/dev/null
+source "$KOKORO_GFILE_DIR/common.sh"
+
 # Grab the latest version of shellcheck and add it to PATH
 if [ -f "$KOKORO_GFILE_DIR"/shellcheck-latest.linux ]; then
     sudo cp "$KOKORO_GFILE_DIR"/shellcheck-latest.linux /usr/local/bin/shellcheck

--- a/testing/lib/BUILD
+++ b/testing/lib/BUILD
@@ -29,7 +29,7 @@ py_library(
 
 docker_build(
     name = "test",
-    base = "@python_base//image",
+    base = "@distroless_base//image",
 )
 
 py_test(


### PR DESCRIPTION
This breaks the remote cache right now, since it has a max size of 512mb.