### PR TITLE
fix writing latency to bigquery in deploy check

### DIFF
--- a/integration_tests/deploy_check.py
+++ b/integration_tests/deploy_check.py
@@ -92,7 +92,7 @@ def _deploy_and_test(appdir, language, is_xrt):
         application_url = test_util.retrieve_url_for_version(version)
         _test_application(application_url)
     except Exception as e:
-        logging.error('Error when contacting application! %s', e)
+        logging.error('Error when contacting application: %s', e)
     finally:
         if version:
             deploy_app.stop_version(version)

--- a/integration_tests/testsuite/deploy_app.py
+++ b/integration_tests/testsuite/deploy_app.py
@@ -74,8 +74,8 @@ def _record_latency_to_bigquery(deploy_latency, language, is_xrt):
                   TABLE_NAME, dataset)
     table_ref = bigquery.TableReference(dataset_ref=dataset,
                                         table_id=TABLE_NAME)
-    client.get_table(table_ref)
-    return client.create_rows(table_ref, row)
+    table = client.get_table(table_ref)
+    return client.create_rows(table, row)
 
 
 def deploy_app_and_record_latency(appdir, language, is_xrt):

--- a/integration_tests/testsuite/deploy_app.py
+++ b/integration_tests/testsuite/deploy_app.py
@@ -72,9 +72,10 @@ def _record_latency_to_bigquery(deploy_latency, language, is_xrt):
     dataset = client.dataset(DATASET_NAME)
     logging.debug('Writing bigquery data to table %s in dataset %s',
                   TABLE_NAME, dataset)
-    table_ref = bigquery.TableReference(dataset_ref=dataset, table_id=TABLE_NAME)
+    table_ref = bigquery.TableReference(dataset_ref=dataset,
+                                        table_id=TABLE_NAME)
     client.get_table(table_ref)
-    return client.create_rows(table, row)
+    return client.create_rows(table_ref, row)
 
 
 def deploy_app_and_record_latency(appdir, language, is_xrt):

--- a/integration_tests/testsuite/deploy_app.py
+++ b/integration_tests/testsuite/deploy_app.py
@@ -72,9 +72,9 @@ def _record_latency_to_bigquery(deploy_latency, language, is_xrt):
     dataset = client.dataset(DATASET_NAME)
     logging.debug('Writing bigquery data to table %s in dataset %s',
                   TABLE_NAME, dataset)
-    table = bigquery.Table(name=TABLE_NAME, dataset=dataset)
-    table.reload()
-    return table.insert_data(row)
+    table_ref = bigquery.TableReference(dataset_ref=dataset, table_id=TABLE_NAME)
+    client.get_table(table_ref)
+    return client.create_rows(table, row)
 
 
 def deploy_app_and_record_latency(appdir, language, is_xrt):
@@ -85,8 +85,12 @@ def deploy_app_and_record_latency(appdir, language, is_xrt):
     # Latency is in seconds round up to 2 decimals
     deploy_latency = round(time.time() - start_time, 2)
 
-    # Store the deploy latency data to bigquery
-    _record_latency_to_bigquery(deploy_latency, language, is_xrt)
+    try:
+        # Store the deploy latency data to bigquery
+        _record_latency_to_bigquery(deploy_latency, language, is_xrt)
+    except Exception as e:
+        # log error, but ignore and try and cleanup version anyway
+        logging.error("Error writing latency to bigquery: %s", e)
     return version, url
 
 


### PR DESCRIPTION
also, handle error correctly if the deployment fails so we don't leak deployed versions.