### PR TITLE
more FTL cache refactors

### DIFF
--- a/ftl/common/builder.py
+++ b/ftl/common/builder.py
@@ -123,16 +123,18 @@ class RuntimeBase(JustApp):
         self._target_creds = docker_creds.DefaultKeychain.Resolve(
             self._target_image)
         self._transport = transport_pool.Http(httplib2.Http, size=_THREADS)
+        self._base_image = docker_image.FromRegistry(
+            self._base_name, self._base_creds, self._transport)
+        self._base_image.__enter__()
         self._cache = cache.Registry(
             repo=self._target_image.as_repository(),
+            namespace=self._namespace,
+            base_image=self._base_image,
             creds=self._target_creds,
             transport=self._transport,
             cache_version=cache_version_str,
             threads=_THREADS,
             mount=[self._base_name])
-        self._base = docker_image.FromRegistry(
-            self._base_name, self._base_creds, self._transport)
-        self._base.__enter__()
         self._descriptor_files = descriptor_files
 
     def Build(self):

--- a/ftl/common/cache_test.py
+++ b/ftl/common/cache_test.py
@@ -35,14 +35,22 @@ class RegistryTest(unittest.TestCase):
 
         # Test when the image exists.
         mock_img.exists.return_value = True
-        c = cache.Registry('fake.gcr.io/google-appengine', None, None)
-        self.assertEquals(c.getEntry(fake_base, 'namespace', 'abc123'),
+        c = cache.Registry(repo='fake.gcr.io/google-appengine',
+                           base_image=fake_base,
+                           namespace='namespace',
+                           creds=None,
+                           transport=None)
+        self.assertEquals(c._getEntry('abc123'),
                           mock_img)
 
         # Test when it does not exist
         mock_img.exists.return_value = False
-        c = cache.Registry('fake.gcr.io/google-appengine', None, None)
-        self.assertIsNone(c.getEntry(fake_base, 'namespace', 'abc123'))
+        c = cache.Registry(repo='fake.gcr.io/google-appengine',
+                           base_image=fake_base,
+                           namespace='namespace',
+                           creds=None,
+                           transport=None)
+        self.assertIsNone(c._getEntry('abc123'))
 
 
 if __name__ == '__main__':

--- a/ftl/node/builder.py
+++ b/ftl/node/builder.py
@@ -38,7 +38,7 @@ class Node(builder.RuntimeBase):
 
     def Build(self):
         lyr_imgs = []
-        lyr_imgs.append(self._base)
+        lyr_imgs.append(self._base_image)
         if ftl_util.has_pkg_descriptor(self._descriptor_files, self._ctx):
             pkg = self.PackageLayer(self._ctx, self._descriptor_files, None,
                                     self._args.destination_path,
@@ -46,8 +46,7 @@ class Node(builder.RuntimeBase):
             cached_pkg_img = None
             if self._args.cache:
                 with ftl_util.Timing("checking cached pkg layer"):
-                    cached_pkg_img = self._cache.Get(
-                        self._base, self._namespace, pkg.GetCacheKey())
+                    cached_pkg_img = self._cache.Get(pkg.GetCacheKey())
             if cached_pkg_img is not None:
                 pkg.SetImage(cached_pkg_img)
             else:
@@ -55,8 +54,7 @@ class Node(builder.RuntimeBase):
                     pkg.BuildLayer()
                 if self._args.cache:
                     with ftl_util.Timing("uploading pkg layer"):
-                        self._cache.Set(self._base, self._namespace,
-                                        pkg.GetCacheKey(), pkg.GetImage())
+                        self._cache.Set(pkg.GetCacheKey(), pkg.GetImage())
             lyr_imgs.append(pkg)
 
         app = self.AppLayer(self._ctx, self._args.destination_path)

--- a/ftl/php/builder.py
+++ b/ftl/php/builder.py
@@ -45,7 +45,7 @@ class PHP(builder.RuntimeBase):
 
     def Build(self):
         lyr_imgs = []
-        lyr_imgs.append(self._base)
+        lyr_imgs.append(self._base_image)
         if ftl_util.has_pkg_descriptor(self._descriptor_files, self._ctx):
             pkgs = self._parse_composer_pkgs()
             # if there are 42 or more packages, revert to using phase 1
@@ -58,8 +58,7 @@ class PHP(builder.RuntimeBase):
                 cached_pkg_img = None
                 if self._args.cache:
                     with ftl_util.Timing("checking cached pkg layer"):
-                        cached_pkg_img = self._cache.Get(
-                            self._base, self._namespace, pkg.GetCacheKey())
+                        cached_pkg_img = self._cache.Get(pkg.GetCacheKey())
                 if cached_pkg_img is not None:
                     pkg.SetImage(cached_pkg_img)
                 else:
@@ -67,8 +66,7 @@ class PHP(builder.RuntimeBase):
                         pkg.BuildLayer()
                     if self._args.cache:
                         with ftl_util.Timing("uploading pkg layer"):
-                            self._cache.Set(self._base, self._namespace,
-                                            pkg.GetCacheKey(), pkg.GetImage())
+                            self._cache.Set(pkg.GetCacheKey(), pkg.GetImage())
                 lyr_imgs.append(pkg)
 
         app = self.AppLayer(self._ctx, self._args.destination_path)

--- a/ftl/python/builder.py
+++ b/ftl/python/builder.py
@@ -54,7 +54,7 @@ class Python(builder.RuntimeBase):
 
     def Build(self):
         lyr_imgs = []
-        lyr_imgs.append(self._base)
+        lyr_imgs.append(self._base_image)
         if ftl_util.has_pkg_descriptor(self._descriptor_files, self._ctx):
 
             interpreter = self.InterpreterLayer(self._venv_dir,
@@ -63,8 +63,7 @@ class Python(builder.RuntimeBase):
             cached_int_img = None
             if self._args.cache:
                 with ftl_util.Timing("checking cached int layer"):
-                    cached_int_img = self._cache.Get(
-                        self._base, self._namespace, interpreter.GetCacheKey())
+                    cached_int_img = self._cache.Get(interpreter.GetCacheKey())
             if cached_int_img is not None:
                 interpreter.SetImage(cached_int_img)
             else:
@@ -72,8 +71,7 @@ class Python(builder.RuntimeBase):
                     interpreter.BuildLayer()
                 if self._args.cache:
                     with ftl_util.Timing("uploading int layer"):
-                        self._cache.Set(self._base, self._namespace,
-                                        interpreter.GetCacheKey(),
+                        self._cache.Set(interpreter.GetCacheKey(),
                                         interpreter.GetImage())
             lyr_imgs.append(interpreter)
 
@@ -94,8 +92,7 @@ class Python(builder.RuntimeBase):
                 cached_pkg_img = None
                 if self._args.cache:
                     with ftl_util.Timing("checking cached pkg layer"):
-                        cached_pkg_img = self._cache.Get(
-                            self._base, self._namespace, pkg.GetCacheKey())
+                        cached_pkg_img = self._cache.Get(pkg.GetCacheKey())
                 if cached_pkg_img is not None:
                     pkg.SetImage(cached_pkg_img)
                 else:
@@ -103,8 +100,7 @@ class Python(builder.RuntimeBase):
                         pkg.BuildLayer()
                     if self._args.cache:
                         with ftl_util.Timing("uploading pkg layer"):
-                            self._cache.Set(self._base, self._namespace,
-                                            pkg.GetCacheKey(), pkg.GetImage())
+                            self._cache.Set(pkg.GetCacheKey(), pkg.GetImage())
                 lyr_imgs.append(pkg)
 
         app = self.AppLayer(self._ctx)


### PR DESCRIPTION
This PR is an addendum to #493, and should only be merged after #493 has gone in.

This code adds a few more refactors to the caching code, most notably moving the `namespace` and `base_image` fields into the cache `Registry` object. This changes the API for `Get()` and `Set()` to only require the cache key to be passed in.

This should have no functional change.

To make review easier, see this comparison between the latest commit in #493 and this branch: https://github.com/nkubala/runtimes-common/compare/ftl_cache...nkubala:ftl_cache_2

cc @aaron-prindle 