### PR TITLE
Add FTL global cache

### DIFF
--- a/ftl/common/args.py
+++ b/ftl/common/args.py
@@ -58,6 +58,13 @@ def base_parser():
         help='Check cache during build (default).')
 
     parser.add_argument(
+        '--global-cache',
+        dest='global_cache',
+        default=False,
+        action='store_true',
+        help='Use global cache')
+
+    parser.add_argument(
         '--no-upload',
         dest='upload',
         action='store_false',

--- a/ftl/common/builder.py
+++ b/ftl/common/builder.py
@@ -134,7 +134,8 @@ class RuntimeBase(JustApp):
             transport=self._transport,
             cache_version=cache_version_str,
             threads=_THREADS,
-            mount=[self._base_name])
+            mount=[self._base_name],
+            use_global=self._args.global_cache)
         self._descriptor_files = descriptor_files
 
     def Build(self):


### PR DESCRIPTION
This code adds a global caching layer in the FTL caching code, that will always be checked first before the local caching layer. Cache misses will be logged in cloudbuild logs, and the code will fall back to checking the local cache before building the layer.

This PR depends on #495, which itself is dependent on #493. They must be merged in order.

The global cache is wrapped in a feature flag, which is turned off by default. Once we settle on a method for populating the global cache, we can enable it.

For ease of review, see this comparison between the latest commit on #495 and the latest commit here: https://github.com/nkubala/runtimes-common/compare/ftl_cache_2...nkubala:global_cache

cc @aaron-prindle @dlorenc 