### PR TITLE
Remove parallelization within a single cloudbuild for integration tests.

### DIFF
--- a/ftl/integration_tests/ftl_php_integration_tests_yaml.py
+++ b/ftl/integration_tests/ftl_php_integration_tests_yaml.py
@@ -26,7 +26,6 @@ def main():
             'name': 'gcr.io/cloud-builders/bazel',
             'args': ['run', '//ftl:php_builder_image', '--', '--norun'],
             'id': 'build-builder',
-            'waitFor': [cloudbuild_yaml['steps'][0]['id']],
         },
     )
 

--- a/ftl/integration_tests/ftl_python_integration_tests_yaml.py
+++ b/ftl/integration_tests/ftl_python_integration_tests_yaml.py
@@ -26,7 +26,6 @@ def main():
             'name': 'gcr.io/cloud-builders/bazel',
             'args': ['run', '//ftl:python_builder_image', '--', '--norun'],
             'id': 'build-builder',
-            'waitFor': [cloudbuild_yaml['steps'][0]['id']],
         },
     )
 

--- a/ftl/integration_tests/util.py
+++ b/ftl/integration_tests/util.py
@@ -28,7 +28,6 @@ def run_test_steps(builder_name, full_name, directory, args):
         {
             'name': 'bazel/ftl:%s' % builder_name,
             'args': args,
-            'waitFor': ['build-builder'],
             'id': 'build-image-%s' % full_name,
         },
         # Then pull it from the registry
@@ -36,7 +35,6 @@ def run_test_steps(builder_name, full_name, directory, args):
             'name': 'gcr.io/cloud-builders/docker',
             'args': ['pull', full_name],
             'id': 'pull-image-%s' % full_name,
-            'waitFor': ['build-image-%s' % full_name],
         },
         # Then test it.
         {
@@ -46,7 +44,6 @@ def run_test_steps(builder_name, full_name, directory, args):
                 '/go_default_test', '-image', full_name,
                 os.path.join(directory, 'structure_test.yaml')
             ],
-            'waitFor': ['pull-image-%s' % full_name],
             'id': 'test-image%s' % full_name
         }
     ]


### PR DESCRIPTION
I believe this fixes the integration tests.