### PR TITLE
The 'gzip' binary will not compress files that end in a set of suffixes.

### DIFF
--- a/ftl/common/ftl_util.py
+++ b/ftl/common/ftl_util.py
@@ -67,7 +67,7 @@ class Timing(object):
 
 
 def zip_dir_to_layer_sha(pkg_dir):
-    tar_path = tempfile.mktemp()
+    tar_path = tempfile.mktemp(suffix=".tar")
     with Timing("tar_runtime_package"):
         subprocess.check_call(['tar', '-C', pkg_dir, '-cf', tar_path, '.'])
 


### PR DESCRIPTION
Name the temporary tar files with a ".tar" suffix to be sure gzip will
compress them.