### PR TITLE
Write cache key mappings to GCS

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,6 +71,15 @@ exports_files(["docker-credential-gcr"])""",
     url = "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v1.4.1/docker-credential-gcr_linux_amd64-1.4.1.tar.gz",
 )
 
+new_http_archive(
+    name = "gsutil",
+    # sha256 = "",
+    type = "tar.gz",
+    build_file_content = """package(default_visibility = ["//visibility:public"])
+exports_files(["gsutil"])""",
+    url = "https://storage.googleapis.com/pub/gsutil.tar.gz",
+)
+
 # TODO(aaron-prindle) cleanup circular dep here by pushing ubuntu_base to GCR
 # OR by moving structure_test to own repo
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,6 +55,27 @@ py_library(
     url = "https://pypi.python.org/packages/source/m/mock/mock-1.0.1.tar.gz",
 )
 
+new_http_archive(
+    name = "retrying",
+    build_file_content = """
+# Rename retrying.py to __init__.py
+genrule(
+    name = "rename",
+    srcs = ["retrying.py"],
+    outs = ["__init__.py"],
+    cmd = "cat $< >$@",
+)
+py_library(
+   name = "retrying",
+   srcs = [":__init__.py"],
+   visibility = ["//visibility:public"],
+)""",
+    # sha256 = "b839dd2d9c117c701430c149956918a423a9863b48b09c90e30a6013e7d2f44f",
+    strip_prefix = "retrying-1.3.3/",
+    type = "tar.gz",
+    url = "https://pypi.python.org/packages/44/ef/beae4b4ef80902f22e3af073397f079c96969c69b2c7d52a57ea9ae61c9d/retrying-1.3.3.tar.gz",
+)
+
 docker_pull(
     name = "python_base",
     digest = "sha256:163a514abdb54f99ba371125e884c612e30d6944628dd6c73b0feca7d31d2fb3",

--- a/ftl/BUILD
+++ b/ftl/BUILD
@@ -98,6 +98,14 @@ pkg_tar(
     package_dir = "/usr/local/bin",
 )
 
+pkg_tar(
+    name = "gsutil",
+    srcs = ["@gsutil//:gsutil"],
+    mode = "0755",
+    package_dir = "/gsutil",
+    symlinks = { "/usr/local/bin/gsutil": "/gsutil/gsutil/gsutil"}
+)
+
 # The node base image sets a default CMD, which causes issues if you run our image with no CMD.
 # So, reset it to [""] before building our py_image.
 docker_build(
@@ -108,6 +116,7 @@ docker_build(
     tars = [
         ":cred_helper.tar",
         ":default_creds.tar",
+        ":gsutil.tar",
     ],
 )
 
@@ -164,6 +173,7 @@ docker_build(
     tars = [
         ":cred_helper.tar",
         ":default_creds.tar",
+        ":gsutil.tar",
     ],
 )
 
@@ -225,6 +235,7 @@ docker_build(
     tars = [
         ":cred_helper.tar",
         ":default_creds.tar",
+        ":gsutil.tar",
     ],
 )
 

--- a/ftl/BUILD
+++ b/ftl/BUILD
@@ -22,6 +22,7 @@ py_library(
     deps = [
         "@containerregistry",
         "@httplib2",
+        "@retrying",
     ],
 )
 
@@ -129,6 +130,7 @@ par_binary(
     deps = [
         "//testing/lib:containerregistry_mock_lib",
         "@containerregistry",
+        "@retrying",
     ],
 )
 
@@ -139,6 +141,7 @@ py_image(
     main = "node/main.py",
     deps = [
         "@containerregistry",
+        "@retrying",
     ],
 )
 
@@ -181,7 +184,7 @@ par_binary(
     name = "python_builder",
     srcs = [":python_lib"],
     main = "python/main.py",
-    deps = ["@containerregistry"],
+    deps = ["@containerregistry", "@retrying"],
 )
 
 py_image(
@@ -191,6 +194,7 @@ py_image(
     main = "python/main.py",
     deps = [
         "@containerregistry",
+        "@retrying",
     ],
 )
 
@@ -209,6 +213,7 @@ par_binary(
     deps = [
         "//testing/lib:containerregistry_mock_lib",
         "@containerregistry",
+        "@retrying",
     ],
 )
 
@@ -246,5 +251,6 @@ py_image(
     main = "php/main.py",
     deps = [
         "@containerregistry",
+        "@retrying",
     ],
 )

--- a/ftl/common/builder.py
+++ b/ftl/common/builder.py
@@ -72,8 +72,8 @@ class JustApp(Base):
             self._ctx = ctx
             self._destination_path = destination_path
 
-        def GetCacheKeyRaw(self):
-            return None
+        # def GetCacheKeyRaw(self):
+        #     return None
 
         def BuildLayer(self):
             """Override."""
@@ -136,7 +136,18 @@ class RuntimeBase(JustApp):
             threads=_THREADS,
             mount=[self._base_name],
             use_global=self._args.global_cache)
+        self._cache_mappings = {}
         self._descriptor_files = descriptor_files
+
+    def GetCacheMappings(self):
+        return self._cache_mappings
+
+    def SaveCacheMappings(self):
+        current_config = ftl_util.GetCacheMappingsFromGCS()
+        for k, v in current_config.iteritems():
+            logging.info('existing mapping: %s -> %s', k, v)
+        # for k, v in mappings.iteritems():
+        #     logging.info('mapping: %s -> %s', k, v)
 
     def Build(self):
         return

--- a/ftl/common/builder.py
+++ b/ftl/common/builder.py
@@ -143,9 +143,27 @@ class RuntimeBase(JustApp):
         return self._cache_mappings
 
     def SaveCacheMappings(self):
-        current_config = ftl_util.GetCacheMappingsFromGCS()
-        for k, v in current_config.iteritems():
-            logging.info('existing mapping: %s -> %s', k, v)
+        if self._cache_mappings == {}:
+            return
+        try:
+            # if not ftl_util.AcquireGCSLock():
+            #     return
+            current_mapping = ftl_util.GetCacheMappingsFromGCS()
+            if not current_mapping:
+                logging.warn('No existing mapping found, creating new mapping.')
+                current_mapping = {}
+            for k, v in current_mapping.iteritems():
+                logging.info('existing mapping: %s -> %s', k, v)
+            for k, v in self._cache_mappings.iteritems():
+                # this will overwrite existing mappings: but as long
+                # as we don't change the cache_key algorithm this
+                # should change nothing
+                current_mapping[k] = v
+            ftl_util.WriteCacheMappingsToGCS(current_mapping)
+        except Exception as e:
+            logging.error(e)
+        finally:
+            ftl_util.RelinquishGCSLock()
         # for k, v in mappings.iteritems():
         #     logging.info('mapping: %s -> %s', k, v)
 

--- a/ftl/common/builder.py
+++ b/ftl/common/builder.py
@@ -72,9 +72,6 @@ class JustApp(Base):
             self._ctx = ctx
             self._destination_path = destination_path
 
-        # def GetCacheKeyRaw(self):
-        #     return None
-
         def BuildLayer(self):
             """Override."""
             buf = cStringIO.StringIO()
@@ -139,21 +136,20 @@ class RuntimeBase(JustApp):
         self._cache_mappings = {}
         self._descriptor_files = descriptor_files
 
-    def GetCacheMappings(self):
-        return self._cache_mappings
-
     def SaveCacheMappings(self):
+        # if we don't have any new mappings to save, just exit
         if self._cache_mappings == {}:
             return
         try:
-            # if not ftl_util.AcquireGCSLock():
-            #     return
+            if not ftl_util.AcquireGCSLock():
+                return
             current_mapping = ftl_util.GetCacheMappingsFromGCS()
             if not current_mapping:
-                logging.warn('No existing mapping found, creating new mapping.')
+                logging.warn('No existing mapping found,'
+                             ' creating new mapping.')
                 current_mapping = {}
             for k, v in current_mapping.iteritems():
-                logging.info('existing mapping: %s -> %s', k, v)
+                logging.debug('existing mapping: %s -> %s', k, v)
             for k, v in self._cache_mappings.iteritems():
                 # this will overwrite existing mappings: but as long
                 # as we don't change the cache_key algorithm this
@@ -164,8 +160,7 @@ class RuntimeBase(JustApp):
             logging.error(e)
         finally:
             ftl_util.RelinquishGCSLock()
-        # for k, v in mappings.iteritems():
-        #     logging.info('mapping: %s -> %s', k, v)
+            os._exit(0)
 
     def Build(self):
         return

--- a/ftl/common/ftl_util.py
+++ b/ftl/common/ftl_util.py
@@ -27,7 +27,7 @@ _CACHE_MAPPING_GCS_PATH = 'gs://ftl-global-cache/mapping.json'
 _GCS_LOCKFILE_PATH = 'gs://ftl-global-cache/mapping.lock'
 
 _GCS_LOCK_RETRIES = 7
-_GCS_LOCK_WAIT_TIME = 200 # milliseconds
+_GCS_LOCK_WAIT_TIME = 200  # milliseconds
 
 # This is a 'whitelist' of values to pass from the
 # config_file of a DockerImage to an Overrides object
@@ -59,6 +59,7 @@ def CfgDctToOverrides(config_dct):
             overrides_dct['env'] = v
     return metadata.Overrides(**overrides_dct)
 
+
 def GetCacheMappingsFromGCS():
     # get mapping file from GCS and load into dict
     try:
@@ -72,6 +73,7 @@ def GetCacheMappingsFromGCS():
     finally:
         os.remove(tmp)
 
+
 @retry(stop_max_attempt_number=_GCS_LOCK_RETRIES,
        wait_fixed=_GCS_LOCK_WAIT_TIME)
 def AcquireGCSLock():
@@ -82,38 +84,38 @@ def AcquireGCSLock():
         logging.debug('lockfile acquired')
         return True
     except subprocess.CalledProcessError as cpe:
-        logging.error('Unable to acquire lockfile from GCS: %s', cpe)
+        logging.error('Unable to acquire lockfile from GCS: %s', cpe.output)
         return False
-    finally:
-        if tmp:
-            os.remove(tmp)
+
 
 def RelinquishGCSLock():
     logging.debug('Relinquishing GCS Lockfile')
     try:
-        _, tmp = tempfile.mkstemp(text=True)
-        command = ['gsutil', 'cp', tmp, _GCS_LOCKFILE_PATH]
+        _, f_name = tempfile.mkstemp(text=True)
+        command = ['gsutil', 'cp', f_name, _GCS_LOCKFILE_PATH]
         subprocess.check_output(command, stderr=subprocess.STDOUT)
         logging.debug('lockfile relinquished')
-    except subprocess.CalledProcessError:
-        logging.error('Unable to relinquish lockfile from GCS')
+    except subprocess.CalledProcessError as cpe:
+        logging.error('Unable to relinquish lockfile from GCS: %s', cpe.output)
     finally:
-        if tmp:
-            os.remove(tmp)
+        if f_name:
+            os.remove(f_name)
+
 
 def WriteCacheMappingsToGCS(cache_mappings):
     logging.debug('Writing cache_mappings to GCS: %s', cache_mappings)
     try:
-        _, tmp = tempfile.mkstemp(text=True)
-        with open(tmp, 'w') as f:
-            json.dump(cache_mappings, f)
-        command = ['gsutil', 'cp', tmp, _CACHE_MAPPING_GCS_PATH]
+        fd, f_name = tempfile.mkstemp(text=True)
+        os.write(fd, json.dumps(cache_mappings))
+        command = ['gsutil', 'cp', f_name, _CACHE_MAPPING_GCS_PATH]
         subprocess.check_output(command, stderr=subprocess.STDOUT)
         logging.debug('mappings written to GCS')
-    except subprocess.CalledProcessError:
-        logging.error('Unable to write mappings to GCS')
+    except subprocess.CalledProcessError as cpe:
+        logging.error('Unable to write mappings to GCS: %s', cpe.output)
     finally:
-        os.remove(tmp)
+        if f_name:
+            os.remove(f_name)
+
 
 class Timing(object):
     def __init__(self, descriptor):

--- a/ftl/common/single_layer_image.py
+++ b/ftl/common/single_layer_image.py
@@ -59,8 +59,6 @@ class CacheableLayer(BaseLayer):
         """
 
     def GetCacheKey(self):
-        # keep track of all mappings here, then after build fork process and 
-        # kick off job to write mappings to GCS master list
         return docker_digest.SHA256(self.GetCacheKeyRaw())
 
     @abc.abstractmethod

--- a/ftl/common/single_layer_image.py
+++ b/ftl/common/single_layer_image.py
@@ -59,6 +59,8 @@ class CacheableLayer(BaseLayer):
         """
 
     def GetCacheKey(self):
+        # keep track of all mappings here, then after build fork process and 
+        # kick off job to write mappings to GCS master list
         return docker_digest.SHA256(self.GetCacheKeyRaw())
 
     @abc.abstractmethod

--- a/ftl/php/builder.py
+++ b/ftl/php/builder.py
@@ -65,7 +65,7 @@ class PHP(builder.RuntimeBase):
                     with ftl_util.Timing("building pkg layer"):
                         pkg.BuildLayer()
                         # keep track of mappings for new cache entries only
-                        mapping = pkg.GetCacheMapping()                        
+                        mapping = pkg.GetCacheMapping()
                         self._cache_mappings[mapping[0]] = mapping[1]
                     if self._args.cache:
                         with ftl_util.Timing("uploading pkg layer"):

--- a/ftl/php/builder.py
+++ b/ftl/php/builder.py
@@ -55,8 +55,6 @@ class PHP(builder.RuntimeBase):
                 pkg = self.PackageLayer(self._ctx, self._descriptor_files,
                                         pkg_txt, self._args.destination_path,
                                         self._args.entrypoint)
-                mapping = pkg.GetCacheMapping()
-                self._cache_mappings[mapping[0]] = mapping[1]
                 cached_pkg_img = None
                 if self._args.cache:
                     with ftl_util.Timing("checking cached pkg layer"):
@@ -66,6 +64,9 @@ class PHP(builder.RuntimeBase):
                 else:
                     with ftl_util.Timing("building pkg layer"):
                         pkg.BuildLayer()
+                        # keep track of mappings for new cache entries only
+                        mapping = pkg.GetCacheMapping()                        
+                        self._cache_mappings[mapping[0]] = mapping[1]
                     if self._args.cache:
                         with ftl_util.Timing("uploading pkg layer"):
                             self._cache.Set(pkg.GetCacheKey(), pkg.GetImage())

--- a/ftl/php/builder.py
+++ b/ftl/php/builder.py
@@ -55,6 +55,8 @@ class PHP(builder.RuntimeBase):
                 pkg = self.PackageLayer(self._ctx, self._descriptor_files,
                                         pkg_txt, self._args.destination_path,
                                         self._args.entrypoint)
+                mapping = pkg.GetCacheMapping()
+                self._cache_mappings[mapping[0]] = mapping[1]
                 cached_pkg_img = None
                 if self._args.cache:
                     with ftl_util.Timing("checking cached pkg layer"):
@@ -73,7 +75,7 @@ class PHP(builder.RuntimeBase):
         with ftl_util.Timing("builder app layer"):
             app.BuildLayer()
         lyr_imgs.append(app)
-        with ftl_util.Timing("stitching lyrs into final image"):
+        with ftl_util.Timing("stitching layers into final image"):
             ftl_image = self.AppendLayersIntoImage(lyr_imgs)
         with ftl_util.Timing("uploading final image"):
             self.StoreImage(ftl_image)
@@ -87,6 +89,9 @@ class PHP(builder.RuntimeBase):
             self._pkg_descriptor = pkg_descriptor
             self._destination_path = destination_path
             self._entrypoint = entrypoint
+
+        def GetCacheMapping(self):
+            return (self.GetCacheKeyRaw(), self.GetCacheKey())
 
         def GetCacheKeyRaw(self):
             if self._pkg_descriptor is not None:

--- a/ftl/php/main.py
+++ b/ftl/php/main.py
@@ -15,6 +15,7 @@
 
 import sys
 import argparse
+import logging
 
 from containerregistry.tools import patched
 
@@ -46,6 +47,11 @@ def main(cli_args):
                 _PHP_CACHE_VERSION)
         with ftl_util.Timing("build process for FTL image"):
             php_ftl.Build()
+    with ftl_util.Timing("GCS mapping upload"):
+        php_ftl.SaveCacheMappings()
+        # mappings = php_ftl.GetCacheMappings()
+        # for k, v in mappings.iteritems():
+            # logging.info('mapping: %s -> %s', k, v)
 
 
 if __name__ == '__main__':

--- a/ftl/php/main.py
+++ b/ftl/php/main.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """A binary for constructing images from a source context."""
 
+import os
 import sys
 import argparse
-import logging
 
 from containerregistry.tools import patched
 
@@ -47,11 +47,10 @@ def main(cli_args):
                 _PHP_CACHE_VERSION)
         with ftl_util.Timing("build process for FTL image"):
             php_ftl.Build()
-    with ftl_util.Timing("GCS mapping upload"):
-        php_ftl.SaveCacheMappings()
-        # mappings = php_ftl.GetCacheMappings()
-        # for k, v in mappings.iteritems():
-            # logging.info('mapping: %s -> %s', k, v)
+    newpid = os.fork()
+    if newpid == 0:
+        with ftl_util.Timing("GCS mapping upload"):
+            php_ftl.SaveCacheMappings()
 
 
 if __name__ == '__main__':

--- a/ftl/python/main.py
+++ b/ftl/python/main.py
@@ -44,7 +44,7 @@ def main(cli_args):
             python_ftl = python_builder.Python(
                 context.Workspace(builder_args.directory),
                 builder_args,
-                _PYTHON_CACHE_VERSION, )
+                _PYTHON_CACHE_VERSION)
         with ftl_util.Timing("build process for FTL image"):
             python_ftl.Build()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ pep8==1.7.0
 flake8==3.2.1
 mock==2.0.0
 pytest==3.0.7
-httplib2 == 0.10.3
-six == 1.9.0
-oauth2client == 4.0.0
-futures == 3.1.1
+httplib2==0.10.3
+six==1.9.0
+oauth2client==4.0.0
+futures==3.1.1
+retrying==1.3.3


### PR DESCRIPTION
This code adds support for keeping track of package (name, version) tuple to cache key mappings in a globally accessible file in GCS. This file will be used by the cache population worker to determine from package layer image digests what packages should be installed.

During the build, only mappings for images that were missed in the cache are remembered; if the image was found in the cache, we can assume the mapping exists in the mapping file. Then at the end of the build, a new worker process is launched to write the mappings to GCS, which should run in the background so that it doesn't affect the overall performance of the build.

A lockfile is used in GCS to eliminate race conditions for the mapping file. This could potentially result in mappings getting dropped if the lock can't be acquired. I argue that this will sort itself out; ultimately we're using the mapping to determine the most commonly requested packages from the cache. This means that if a package is only requested a few times and its mapping doesn't make it into the mapping file, we likely won't need to look at it anyway. Conversely, if a package is requested many times, the likelihood of it successfully being written to the mapping file is high.

@aaron-prindle @dlorenc 