### PR TITLE
Refactor to expose builders for individual package layers

### DIFF
--- a/ftl/common/args.py
+++ b/ftl/common/args.py
@@ -94,7 +94,7 @@ def base_parser():
     parser.add_argument(
         "-v",
         "--verbosity",
-        default="NOTSET",
+        default=constants.DEFAULT_LOG_LEVEL,
         nargs="?",
         action='store',
         choices=logger.LEVEL_MAP.keys())

--- a/ftl/common/args.py
+++ b/ftl/common/args.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """This package defines the shared cli args for ftl binaries."""
 
+from ftl.common import constants
 from ftl.common import logger
 import argparse
 
@@ -102,14 +103,14 @@ def base_parser():
         '--destination',
         dest='destination_path',
         action='store',
-        default='srv',
+        default=constants.DEFAULT_DESTINATION_PATH,
         help='The base path that the app and dependency files will be \
         installed in the final image')
     parser.add_argument(
         '--entrypoint',
         dest='entrypoint',
         action='store',
-        default=None,
+        default=constants.DEFAULT_ENTRYPOINT,
         help='The entrypoint for the dockerimage')
     parser.add_argument(
         '--exposed_ports',

--- a/ftl/common/builder_test.py
+++ b/ftl/common/builder_test.py
@@ -18,6 +18,7 @@ import unittest
 import tarfile
 
 import builder
+import layer_builder
 import context
 
 
@@ -35,9 +36,9 @@ class JustAppTest(unittest.TestCase):
             ctx.AddFile(p, f)
 
         b = builder.JustApp(ctx)
-        app = b.AppLayer(b._ctx)
-        app.BuildLayer()
-        app_layer = app.GetImage().GetFirstBlob()
+        app_builder = layer_builder.AppLayerBuilder(b._ctx)
+        app_builder.BuildLayer()
+        app_layer = app_builder.GetImage().GetFirstBlob()
         stream = cStringIO.StringIO(app_layer)
         with tarfile.open(fileobj=stream, mode='r:gz') as tf:
             self.assertEqual(len(tf.getnames()), len(files))

--- a/ftl/common/cache.py
+++ b/ftl/common/cache.py
@@ -18,16 +18,14 @@ import hashlib
 import logging
 import datetime
 
+from ftl.common import constants
+
 from containerregistry.client import docker_name
 from containerregistry.client import docker_creds
 from containerregistry.client.v2_2 import docker_image
 from containerregistry.client.v2_2 import docker_session
 
 from ftl.common import ftl_util
-
-_DEFAULT_TTL_WEEKS = 1
-
-_GLOBAL_CACHE_REGISTRY = 'gcr.io/ftl-global-cache'
 
 
 class Base(object):
@@ -86,8 +84,9 @@ class Registry(Base):
         self._base_image = base_image
         self._namespace = namespace
         self._creds = creds
-        _reg_name = '{base}/{namespace}'.format(base=_GLOBAL_CACHE_REGISTRY,
-                                                namespace=self._namespace)
+        _reg_name = '{base}/{namespace}'.format(
+            base=constants.GLOBAL_CACHE_REGISTRY,
+            namespace=self._namespace)
         # TODO(nkubala): default this to true to point builds to global cache
         self._use_global = use_global
         if use_global:
@@ -132,7 +131,7 @@ class Registry(Base):
 
     def _getGlobalEntry(self, cache_key):
         if self._use_global:
-            key = self._tag(cache_key, _GLOBAL_CACHE_REGISTRY)
+            key = self._tag(cache_key, constants.GLOBAL_CACHE_REGISTRY)
             entry = Registry.getEntryFromCreds(key, self._global_creds,
                                                self._transport)
             if not entry:
@@ -176,4 +175,4 @@ class Registry(Base):
                 ftl_util.creation_time(entry))
         now = datetime.datetime.now()
         return last_created > now - datetime.timedelta(
-                weeks=_DEFAULT_TTL_WEEKS)
+                weeks=constants.DEFAULT_TTL_WEEKS)

--- a/ftl/common/constants.py
+++ b/ftl/common/constants.py
@@ -1,0 +1,21 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DEFAULT_DESTINATION_PATH = 'srv'
+DEFAULT_ENTRYPOINT = None
+
+NODE_NAMESPACE = 'node-package-lock-cache'
+PACKAGE_LOCK = 'package-lock.json'
+PACKAGE_JSON = 'package.json'
+NODE_DEFAULT_ENTRYPOINT = 'node server.js'

--- a/ftl/common/constants.py
+++ b/ftl/common/constants.py
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DEFAULT_LOG_LEVEL = "NOTSET"
+
 DEFAULT_DESTINATION_PATH = 'srv'
 DEFAULT_ENTRYPOINT = None
 
+# cache constants
+DEFAULT_TTL_WEEKS = 1
+GLOBAL_CACHE_REGISTRY = 'gcr.io/ftl-global-cache'
+
+# node constants
 NODE_NAMESPACE = 'node-package-lock-cache'
 PACKAGE_LOCK = 'package-lock.json'
 PACKAGE_JSON = 'package.json'

--- a/ftl/common/layer_builder.py
+++ b/ftl/common/layer_builder.py
@@ -1,0 +1,71 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cStringIO
+import datetime
+import os
+import tarfile
+import logging
+import subprocess
+
+from ftl.common import constants
+from ftl.common import single_layer_image
+from ftl.common import tar_to_dockerimage
+
+
+class AppLayerBuilder(single_layer_image.BaseLayerBuilder):
+    def __init__(self, ctx,
+                 destination_path=constants.DEFAULT_DESTINATION_PATH,
+                 entrypoint=constants.DEFAULT_ENTRYPOINT, exposed_ports=None):
+        self._ctx = ctx
+        self._destination_path = destination_path
+        self._entrypoint = entrypoint
+        self._exposed_ports = exposed_ports
+
+    def GetCacheKeyRaw(self):
+        return None
+
+    def BuildLayer(self):
+        """Override."""
+        buf = cStringIO.StringIO()
+        logging.info('Starting to generate app layer \
+            tarfile from context...')
+        with tarfile.open(fileobj=buf, mode='w') as out:
+            for name in self._ctx.ListFiles():
+                content = self._ctx.GetFile(name)
+                info = tarfile.TarInfo(
+                    os.path.join(self._destination_path.strip("/"), name))
+                info.size = len(content)
+                out.addfile(info, fileobj=cStringIO.StringIO(content))
+        logging.info('Finished generating app layer tarfile from context.')
+
+        tar = buf.getvalue()
+
+        logging.info('Starting to gzip app layer tarfile...')
+        gzip_process = subprocess.Popen(
+            ['gzip', '-f'],
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+        gz = gzip_process.communicate(input=tar)[0]
+        overrides_dct = {
+                'created': str(datetime.date.today()) + "T00:00:00Z"
+            }
+        if self._entrypoint:
+            overrides_dct['Entrypoint'] = self._entrypoint
+        if self._exposed_ports:
+            overrides_dct['ExposedPorts'] = self._exposed_ports
+        logging.info('Finished gzipping tarfile.')
+        self._img = tar_to_dockerimage.FromFSImage([gz], [tar],
+                                                   overrides_dct)

--- a/ftl/common/single_layer_image.py
+++ b/ftl/common/single_layer_image.py
@@ -11,15 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""This package defines the shared cli args for ftl binaries."""
+"""This package defines abstract methods for
+building individual image layers."""
 
 import abc
 
 from containerregistry.client.v2_2 import docker_digest
 
 
-class BaseLayer(object):
-    """BaseLayer is an abstract base class representing a container layer.
+class BaseLayerBuilder(object):
+    """BaseLayerBuilder is an abstract base class representing
+    a builder for a container layer.
 
     It provides methods for generating a dependency layer and an application
     layer.
@@ -47,7 +49,7 @@ class BaseLayer(object):
         """
 
 
-class CacheableLayer(BaseLayer):
+class CacheableLayerBuilder(BaseLayerBuilder):
 
     __metaclass__ = abc.ABCMeta  # For enforcing that methods are overriden.
 

--- a/ftl/node/builder.py
+++ b/ftl/node/builder.py
@@ -13,53 +13,48 @@
 # limitations under the License.
 """This package defines the interface for orchestrating image builds."""
 
-import os
-import subprocess
-import tempfile
-import json
-import datetime
-
 from ftl.common import builder
+from ftl.common import constants
 from ftl.common import ftl_util
-from ftl.common import single_layer_image
-from ftl.common import tar_to_dockerimage
-
-_NODE_NAMESPACE = 'node-package-lock-cache'
-_PACKAGE_LOCK = 'package-lock.json'
-_PACKAGE_JSON = 'package.json'
-_DEFAULT_ENTRYPOINT = 'node server.js'
+from ftl.common import layer_builder as base_builder
+from ftl.node import layer_builder as node_builder
 
 
 class Node(builder.RuntimeBase):
     def __init__(self, ctx, args, cache_version_str):
-        super(Node,
-              self).__init__(ctx, _NODE_NAMESPACE, args, cache_version_str,
-                             [_PACKAGE_LOCK, _PACKAGE_JSON])
+        super(
+            Node, self).__init__(
+            ctx, constants.NODE_NAMESPACE, args, cache_version_str, [
+                constants.PACKAGE_LOCK, constants.PACKAGE_JSON])
 
     def Build(self):
         lyr_imgs = []
         lyr_imgs.append(self._base_image)
         if ftl_util.has_pkg_descriptor(self._descriptor_files, self._ctx):
-            pkg = self.PackageLayer(self._ctx, self._descriptor_files, None,
-                                    self._args.destination_path,
-                                    self._args.exposed_ports)
+            layer_builder = node_builder.LayerBuilder(
+                ctx=self._ctx,
+                descriptor_files=self._descriptor_files,
+                destination_path=self._args.destination_path)
             cached_pkg_img = None
             if self._args.cache:
                 with ftl_util.Timing("checking cached pkg layer"):
-                    cached_pkg_img = self._cache.Get(pkg.GetCacheKey())
+                    key = layer_builder.GetCacheKey()
+                    cached_pkg_img = self._cache.Get(key)
             if cached_pkg_img is not None:
-                pkg.SetImage(cached_pkg_img)
+                layer_builder.SetImage(cached_pkg_img)
             else:
                 with ftl_util.Timing("building pkg layer"):
-                    pkg.BuildLayer()
+                    layer_builder.BuildLayer()
                 if self._args.cache:
                     with ftl_util.Timing("uploading pkg layer"):
-                        self._cache.Set(pkg.GetCacheKey(), pkg.GetImage())
-            lyr_imgs.append(pkg)
+                        self._cache.Set(layer_builder.GetCacheKey(),
+                                        layer_builder.GetImage())
+            lyr_imgs.append(layer_builder)
 
-        app = self.AppLayer(self._ctx, self._args.destination_path,
-                            self._args.entrypoint,
-                            self._args.exposed_ports)
+        app = base_builder.AppLayerBuilder(self._ctx,
+                                           self._args.destination_path,
+                                           self._args.entrypoint,
+                                           self._args.exposed_ports)
         with ftl_util.Timing("builder app layer"):
             app.BuildLayer()
         lyr_imgs.append(app)
@@ -67,87 +62,3 @@ class Node(builder.RuntimeBase):
             ftl_image = self.AppendLayersIntoImage(lyr_imgs)
         with ftl_util.Timing("uploading final image"):
             self.StoreImage(ftl_image)
-
-    class PackageLayer(single_layer_image.CacheableLayer):
-        def __init__(self, ctx, descriptor_files, pkg_descriptor,
-                     destination_path, exposed_ports):
-            super(Node.PackageLayer, self).__init__()
-            self._ctx = ctx
-            self._descriptor_files = descriptor_files
-            self._pkg_descriptor = pkg_descriptor
-            self._destination_path = destination_path
-            self._exposed_ports = exposed_ports
-
-        def GetCacheKeyRaw(self):
-            return ftl_util.descriptor_parser(self._descriptor_files,
-                                              self._ctx)
-
-        def BuildLayer(self):
-            """Override."""
-            blob, u_blob = self._gen_npm_install_tar(self._pkg_descriptor,
-                                                     self._destination_path)
-            self._img = tar_to_dockerimage.FromFSImage(
-                [blob], [u_blob], self._generate_overrides())
-
-        def _gen_npm_install_tar(self, pkg_descriptor, destination_path):
-            # Create temp directory to write package descriptor to
-            pkg_dir = tempfile.mkdtemp()
-            app_dir = os.path.join(pkg_dir, destination_path.strip("/"))
-            os.makedirs(app_dir)
-
-            # Copy out the relevant package descriptors to a tempdir.
-            ftl_util.descriptor_copy(self._ctx, self._descriptor_files,
-                                     app_dir)
-
-            self._check_gcp_build(
-                json.loads(self._ctx.GetFile(_PACKAGE_JSON)), app_dir)
-            subprocess.check_call(
-                ['rm', '-rf',
-                 os.path.join(app_dir, 'node_modules')])
-            with ftl_util.Timing("npm_install"):
-                if pkg_descriptor is None:
-                    subprocess.check_call(
-                        ['npm', 'install', '--production'], cwd=app_dir)
-                else:
-                    subprocess.check_call(
-                        ['npm', 'install', '--production', pkg_descriptor],
-                        cwd=app_dir)
-
-            return ftl_util.zip_dir_to_layer_sha(pkg_dir)
-
-        def _generate_overrides(self):
-            pj_contents = {}
-            if self._ctx.Contains(_PACKAGE_JSON):
-                pj_contents = json.loads(self._ctx.GetFile(_PACKAGE_JSON))
-            entrypoint = self._parse_entrypoint(pj_contents)
-            overrides_dct = {
-                'created': str(datetime.date.today()) + "T00:00:00Z",
-                'Entrypoint': entrypoint,
-            }
-            return overrides_dct
-
-        def _check_gcp_build(self, package_json, app_dir):
-            scripts = package_json.get('scripts', {})
-            gcp_build = scripts.get('gcp-build')
-
-            if not gcp_build:
-                return
-
-            env = os.environ.copy()
-            env["NODE_ENV"] = "development"
-            subprocess.check_call(['npm', 'install'], cwd=app_dir, env=env)
-            subprocess.check_call(
-                ['npm', 'run-script', 'gcp-build'], cwd=app_dir, env=env)
-
-        def _parse_entrypoint(self, package_json):
-            entrypoint = []
-
-            scripts = package_json.get('scripts', {})
-            start = scripts.get('start', _DEFAULT_ENTRYPOINT)
-            prestart = scripts.get('prestart')
-
-            if prestart:
-                entrypoint = '%s && %s' % (prestart, start)
-            else:
-                entrypoint = start
-            return ['sh', '-c', entrypoint]

--- a/ftl/node/layer_builder.py
+++ b/ftl/node/layer_builder.py
@@ -1,0 +1,110 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This package implements the Node package layer builder."""
+
+
+import os
+import subprocess
+import tempfile
+import json
+import datetime
+
+from ftl.common import constants
+from ftl.common import ftl_util
+from ftl.common import single_layer_image
+from ftl.common import tar_to_dockerimage
+
+
+class LayerBuilder(single_layer_image.CacheableLayerBuilder):
+    def __init__(self, ctx=None, descriptor_files=None, pkg_descriptor=None,
+                 destination_path=constants.DEFAULT_DESTINATION_PATH):
+        super(LayerBuilder, self).__init__()
+        self._ctx = ctx
+        self._descriptor_files = descriptor_files
+        self._pkg_descriptor = pkg_descriptor
+        self._destination_path = destination_path
+
+    def GetCacheKeyRaw(self):
+        return ftl_util.descriptor_parser(self._descriptor_files,
+                                          self._ctx)
+
+    def BuildLayer(self):
+        """Override."""
+        blob, u_blob = self._gen_npm_install_tar(self._pkg_descriptor,
+                                                 self._destination_path)
+        self._img = tar_to_dockerimage.FromFSImage(
+            [blob], [u_blob], self._generate_overrides())
+
+    def _gen_npm_install_tar(self, pkg_descriptor, destination_path):
+        # Create temp directory to write package descriptor to
+        pkg_dir = tempfile.mkdtemp()
+        app_dir = os.path.join(pkg_dir, destination_path.strip("/"))
+        os.makedirs(app_dir)
+
+        # Copy out the relevant package descriptors to a tempdir.
+        ftl_util.descriptor_copy(self._ctx, self._descriptor_files,
+                                 app_dir)
+
+        self._check_gcp_build(
+            json.loads(self._ctx.GetFile(constants.PACKAGE_JSON)), app_dir)
+        subprocess.check_call(
+            ['rm', '-rf',
+                os.path.join(app_dir, 'node_modules')])
+        with ftl_util.Timing("npm_install"):
+            if pkg_descriptor is None:
+                subprocess.check_call(
+                    ['npm', 'install', '--production'], cwd=app_dir)
+            else:
+                subprocess.check_call(
+                    ['npm', 'install', '--production', pkg_descriptor],
+                    cwd=app_dir)
+
+        return ftl_util.zip_dir_to_layer_sha(pkg_dir)
+
+    def _generate_overrides(self):
+        pj_contents = {}
+        if self._ctx.Contains(constants.PACKAGE_JSON):
+            pj_contents = json.loads(self._ctx.GetFile(constants.PACKAGE_JSON))
+        entrypoint = self._parse_entrypoint(pj_contents)
+        overrides_dct = {
+            'created': str(datetime.date.today()) + "T00:00:00Z",
+            'Entrypoint': entrypoint,
+        }
+        return overrides_dct
+
+    def _check_gcp_build(self, package_json, app_dir):
+        scripts = package_json.get('scripts', {})
+        gcp_build = scripts.get('gcp-build')
+
+        if not gcp_build:
+            return
+
+        env = os.environ.copy()
+        env["NODE_ENV"] = "development"
+        subprocess.check_call(['npm', 'install'], cwd=app_dir, env=env)
+        subprocess.check_call(
+            ['npm', 'run-script', 'gcp-build'], cwd=app_dir, env=env)
+
+    def _parse_entrypoint(self, package_json):
+        entrypoint = []
+
+        scripts = package_json.get('scripts', {})
+        start = scripts.get('start', constants.NODE_DEFAULT_ENTRYPOINT)
+        prestart = scripts.get('prestart')
+
+        if prestart:
+            entrypoint = '%s && %s' % (prestart, start)
+        else:
+            entrypoint = start
+        return ['sh', '-c', entrypoint]

--- a/ftl/php/builder.py
+++ b/ftl/php/builder.py
@@ -13,16 +13,13 @@
 # limitations under the License.
 """This package defines the interface for orchestrating image builds."""
 
-import os
-import subprocess
-import tempfile
-import datetime
+import logging
 import json
 
 from ftl.common import builder
 from ftl.common import ftl_util
-from ftl.common import single_layer_image
-from ftl.common import tar_to_dockerimage
+from ftl.common import layer_builder as base_builder
+from ftl.php import layer_builder as php_builder
 
 _PHP_NAMESPACE = 'php-package-lock-cache'
 _COMPOSER_LOCK = 'composer.lock'
@@ -52,25 +49,34 @@ class PHP(builder.RuntimeBase):
             if len(pkgs) > 41:
                 pkgs = [None]
             for pkg_txt in pkgs:
-                pkg = self.PackageLayer(self._ctx, self._descriptor_files,
-                                        pkg_txt, self._args.destination_path)
+                logging.info('building package layer')
+                logging.info(pkg_txt)
+                layer_builder = php_builder.LayerBuilder(
+                    ctx=self._ctx,
+                    descriptor_files=self._descriptor_files,
+                    pkg_descriptor=pkg_txt,
+                    destination_path=self._args.destination_path)
                 cached_pkg_img = None
                 if self._args.cache:
                     with ftl_util.Timing("checking cached pkg layer"):
-                        cached_pkg_img = self._cache.Get(pkg.GetCacheKey())
+                        key = layer_builder.GetCacheKey()
+                        cached_pkg_img = self._cache.Get(key)
                 if cached_pkg_img is not None:
-                    pkg.SetImage(cached_pkg_img)
+                    layer_builder.SetImage(cached_pkg_img)
                 else:
                     with ftl_util.Timing("building pkg layer"):
-                        pkg.BuildLayer()
+                        layer_builder.BuildLayer()
                     if self._args.cache:
                         with ftl_util.Timing("uploading pkg layer"):
-                            self._cache.Set(pkg.GetCacheKey(), pkg.GetImage())
-                lyr_imgs.append(pkg)
+                            self._cache.Set(layer_builder.GetCacheKey(),
+                                            layer_builder.GetImage())
+                lyr_imgs.append(layer_builder)
 
-        app = self.AppLayer(self._ctx, self._args.destination_path,
-                            self._args.entrypoint,
-                            self._args.exposed_ports)
+        app = base_builder.AppLayerBuilder(
+            ctx=self._ctx,
+            destination_path=self._args.destination_path,
+            entrypoint=self._args.entrypoint,
+            exposed_ports=self._args.exposed_ports)
         with ftl_util.Timing("builder app layer"):
             app.BuildLayer()
         lyr_imgs.append(app)
@@ -78,60 +84,3 @@ class PHP(builder.RuntimeBase):
             ftl_image = self.AppendLayersIntoImage(lyr_imgs)
         with ftl_util.Timing("uploading final image"):
             self.StoreImage(ftl_image)
-
-    class PackageLayer(single_layer_image.CacheableLayer):
-        def __init__(self, ctx, descriptor_files, pkg_descriptor,
-                     destination_path):
-            super(PHP.PackageLayer, self).__init__()
-            self._ctx = ctx
-            self._descriptor_files = descriptor_files
-            self._pkg_descriptor = pkg_descriptor
-            self._destination_path = destination_path
-
-        def GetCacheKeyRaw(self):
-            if self._pkg_descriptor is not None:
-                # phase 2 cache key
-                return self._pkg_descriptor[0] + ' ' + self._pkg_descriptor[1]
-            # phase 1 cache key
-            return ftl_util.descriptor_parser(self._descriptor_files,
-                                              self._ctx)
-
-        def BuildLayer(self):
-            """Override."""
-            blob, u_blob = self._gen_composer_install_tar(
-                self._pkg_descriptor, self._destination_path)
-            overrides_dct = {
-                    'created': str(datetime.date.today()) + "T00:00:00Z"
-                }
-            self._img = tar_to_dockerimage.FromFSImage(
-                [blob], [u_blob], overrides_dct)
-
-        def _gen_composer_install_tar(self, pkg_descriptor, destination_path):
-            # Create temp directory to write package descriptor to
-            pkg_dir = tempfile.mkdtemp()
-            app_dir = os.path.join(pkg_dir, destination_path.strip("/"))
-            os.makedirs(app_dir)
-
-            # Copy out the relevant package descriptors to a tempdir.
-            if pkg_descriptor is None:
-                # phase 1 copy whole descriptor
-                ftl_util.descriptor_copy(self._ctx, self._descriptor_files,
-                                         app_dir)
-
-            subprocess.check_call(
-                ['rm', '-rf', os.path.join(app_dir, 'vendor')])
-
-            with ftl_util.Timing("composer_install"):
-                if pkg_descriptor is None:
-                    # phase 1 install entire descriptor
-                    subprocess.check_call(
-                        ['composer', 'install', '--no-dev', '--no-scripts'],
-                        cwd=app_dir)
-                else:
-                    pkg, version = pkg_descriptor
-                    subprocess.check_call(
-                        ['composer', 'require',
-                         str(pkg),
-                         str(version)],
-                        cwd=app_dir)
-            return ftl_util.zip_dir_to_layer_sha(pkg_dir)

--- a/ftl/php/layer_builder.py
+++ b/ftl/php/layer_builder.py
@@ -1,0 +1,83 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This package implements the PHP package layer builder."""
+
+import os
+import subprocess
+import tempfile
+import datetime
+
+from ftl.common import constants
+from ftl.common import ftl_util
+from ftl.common import single_layer_image
+from ftl.common import tar_to_dockerimage
+
+
+class LayerBuilder(single_layer_image.CacheableLayerBuilder):
+    def __init__(self, ctx=None, descriptor_files=None, pkg_descriptor=None,
+                 destination_path=constants.DEFAULT_DESTINATION_PATH):
+        super(LayerBuilder, self).__init__()
+        self._ctx = ctx
+        self._descriptor_files = descriptor_files
+        self._pkg_descriptor = pkg_descriptor
+        self._destination_path = destination_path
+
+    def GetCacheKeyRaw(self):
+        if self._pkg_descriptor is not None:
+            # phase 2 cache key
+            return self._pkg_descriptor[0] + ' ' + self._pkg_descriptor[1]
+        # phase 1 cache key
+        return ftl_util.descriptor_parser(self._descriptor_files,
+                                          self._ctx)
+
+    def BuildLayer(self):
+        """Override."""
+        blob, u_blob = self._gen_composer_install_tar(
+            self._pkg_descriptor, self._destination_path)
+        overrides_dct = {
+            'created': str(datetime.date.today()) + "T00:00:00Z"
+        }
+        self._img = tar_to_dockerimage.FromFSImage(
+            [blob], [u_blob], overrides_dct)
+
+    def _gen_composer_install_tar(self, pkg_descriptor, destination_path):
+        # Create temp directory to write package descriptor to
+        pkg_dir = tempfile.mkdtemp()
+        app_dir = os.path.join(pkg_dir, destination_path.strip("/"))
+        print 'app_dir: %s' % app_dir
+        os.makedirs(app_dir)
+
+        # Copy out the relevant package descriptors to a tempdir.
+        if pkg_descriptor is None:
+            # phase 1 copy whole descriptor
+            ftl_util.descriptor_copy(self._ctx, self._descriptor_files,
+                                     app_dir)
+
+        subprocess.check_call(
+            ['rm', '-rf', os.path.join(app_dir, 'vendor')])
+
+        with ftl_util.Timing("composer_install"):
+            if pkg_descriptor is None:
+                # phase 1 install entire descriptor
+                subprocess.check_call(
+                    ['composer', 'install', '--no-dev', '--no-scripts'],
+                    cwd=app_dir)
+            else:
+                pkg, version = pkg_descriptor
+                subprocess.check_call(
+                    ['composer', 'require',
+                        str(pkg),
+                        str(version)],
+                    cwd=app_dir)
+        return ftl_util.zip_dir_to_layer_sha(pkg_dir)

--- a/ftl/python/layer_builder.py
+++ b/ftl/python/layer_builder.py
@@ -1,0 +1,79 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This package implements the Python package layer builder."""
+
+import datetime
+import os
+import subprocess
+
+from ftl.common import ftl_util
+from ftl.common import single_layer_image
+from ftl.common import tar_to_dockerimage
+
+
+class PackageLayerBuilder(single_layer_image.CacheableLayerBuilder):
+    def __init__(self, ctx, descriptor_files, pkg_dir, dep_img_lyr):
+        super(PackageLayerBuilder, self).__init__()
+        self._ctx = ctx
+        self._pkg_dir = pkg_dir
+        self._descriptor_files = descriptor_files
+        self._dep_img_lyr = dep_img_lyr
+
+    def GetCacheKeyRaw(self):
+        descriptor_contents = ftl_util.descriptor_parser(
+            self._descriptor_files, self._ctx)
+        return "%s %s" % (descriptor_contents,
+                          self._dep_img_lyr.GetCacheKeyRaw())
+
+    def BuildLayer(self):
+        blob, u_blob = ftl_util.zip_dir_to_layer_sha(self._pkg_dir)
+        self._img = tar_to_dockerimage.FromFSImage(
+            [blob], [u_blob], _generate_overrides(False))
+
+
+class InterpreterLayerBuilder(single_layer_image.CacheableLayerBuilder):
+    def __init__(self, venv_dir, python_version):
+        super(InterpreterLayerBuilder, self).__init__()
+        self._venv_dir = venv_dir
+        self._python_version = python_version
+
+    def GetCacheKeyRaw(self):
+        return self._python_version
+
+    def BuildLayer(self):
+        self._setup_venv(self._python_version)
+        blob, u_blob = ftl_util.zip_dir_to_layer_sha(
+            os.path.abspath(os.path.join(self._venv_dir, os.pardir)))
+        self._img = tar_to_dockerimage.FromFSImage(
+            [blob], [u_blob], _generate_overrides(True))
+
+    def _setup_venv(self, python_version):
+        with ftl_util.Timing("create_virtualenv"):
+            subprocess.check_call([
+                'virtualenv', '--no-download', self._venv_dir, '-p',
+                python_version
+            ])
+
+
+def _generate_overrides(set_path):
+    env = {
+        "VIRTUAL_ENV": "/env",
+    }
+    if set_path:
+        env['PATH'] = '/env/bin:$PATH'
+    overrides_dct = {
+        "created": str(datetime.date.today()) + "T00:00:00Z",
+        "env": env
+    }
+    return overrides_dct


### PR DESCRIPTION
This refactors the FTL code to expose the individual package layer builders, so they can be used outside of a full FTL build. This will be used immediately to populate the global cache, but could also potentially be used in other places where we might need individual package layers.

This should have no functional change.

cc @aaron-prindle @dlorenc 