### PR TITLE
fix python caching

### DIFF
--- a/ftl/common/builder.py
+++ b/ftl/common/builder.py
@@ -114,7 +114,10 @@ class RuntimeBase(JustApp):
     def AppendLayersIntoImage(self, lyr_imgs):
         for i, lyr_img in enumerate(lyr_imgs):
             if i == 0:
-                result_image = lyr_img
+                try:
+                    result_image = lyr_img.GetImage()
+                except AttributeError:
+                    result_image = lyr_img
                 continue
             img = lyr_img.GetImage()
             diff_ids = img.diff_ids()

--- a/ftl/common/single_layer_image.py
+++ b/ftl/common/single_layer_image.py
@@ -34,8 +34,8 @@ class BaseLayerBuilder(object):
 
     def GetImage(self):
         if self._img is None:
-            raise Exception('error: layer image was not built yet so \
-                             image cannot be accessed')
+            raise Exception('error: layer image was not built yet so ' +
+                            'image cannot be accessed')
         return self._img
 
     def SetImage(self, img):


### PR DESCRIPTION
this pr fixes python caching to allow for rebuilding of python images to not have to pip install any packages.  this was done by caching/uploading an image that is the full set of deps from a requirements.txt file