### PR TITLE
add logging for all cache activity, and move logic to build layers into builders

### DIFF
--- a/ftl/cached/BUILD
+++ b/ftl/cached/BUILD
@@ -10,6 +10,7 @@ py_library(
     srcs = glob(["*.py"]),
     deps = [
         "@containerregistry",
+        "@mock",
     ],
 )
 

--- a/ftl/common/builder.py
+++ b/ftl/common/builder.py
@@ -16,11 +16,9 @@ import abc
 import tarfile
 import logging
 import httplib2
-import json
 
 from containerregistry.client import docker_creds
 from containerregistry.client import docker_name
-from containerregistry.client.v2_2 import append
 from containerregistry.client.v2_2 import docker_image
 from containerregistry.client.v2_2 import docker_session
 from containerregistry.client.v2_2 import save
@@ -70,7 +68,7 @@ class RuntimeBase(JustApp):
     It provides methods for generating appending layers and caching images
     """
 
-    def __init__(self, ctx, namespace, args, cache_version_str,
+    def __init__(self, ctx, namespace, args,
                  descriptor_files):
         super(RuntimeBase, self).__init__(ctx)
         self._namespace = namespace
@@ -102,7 +100,6 @@ class RuntimeBase(JustApp):
             base_image=self._base_image,
             creds=self._target_creds,
             transport=self._transport,
-            cache_version=cache_version_str,
             threads=_THREADS,
             mount=[self._base_name],
             use_global=args.global_cache,
@@ -113,41 +110,24 @@ class RuntimeBase(JustApp):
     def Build(self):
         return
 
-    def AppendLayersIntoImage(self, lyr_imgs):
-        for i, lyr_img in enumerate(lyr_imgs):
-            if i == 0:
-                try:
-                    result_image = lyr_img.GetImage()
-                except AttributeError:
-                    result_image = lyr_img
-                continue
-            img = lyr_img.GetImage()
-            diff_ids = img.diff_ids()
-            for diff_id in diff_ids:
-                lyr = img.blob(img._diff_id_to_digest(diff_id))
-                overrides = ftl_util.CfgDctToOverrides(
-                    json.loads(img.config_file()))
-                result_image = append.Layer(
-                    result_image, lyr, diff_id=diff_id, overrides=overrides)
-        return result_image
-
     def StoreImage(self, result_image):
-        if self._args.output_path:
-            with ftl_util.Timing("saving_tarball_image"):
-                with tarfile.open(
-                        name=self._args.output_path, mode='w') as tar:
-                    save.tarball(self._target_image, result_image, tar)
-                logging.info("{0} tarball located at {1}".format(
-                    str(self._target_image), self._args.output_path))
-            return
-        if self._args.upload:
-            with ftl_util.Timing("pushing_image_to_docker_registry"):
-                with docker_session.Push(
-                        self._target_image,
-                        self._target_creds,
-                        self._transport,
-                        threads=_THREADS,
-                        mount=[self._base_name]) as session:
-                    logging.info('Pushing final image...')
-                    session.upload(result_image)
+        with ftl_util.Timing('Uploading final image'):
+            if self._args.output_path:
+                with ftl_util.Timing('Saving tarball image'):
+                    with tarfile.open(
+                            name=self._args.output_path, mode='w') as tar:
+                        save.tarball(self._target_image, result_image, tar)
+                    logging.info('{0} tarball located at {1}'.format(
+                        str(self._target_image), self._args.output_path))
                 return
+            if self._args.upload:
+                with ftl_util.Timing('Pushing image to Docker registry'):
+                    with docker_session.Push(
+                            self._target_image,
+                            self._target_creds,
+                            self._transport,
+                            threads=_THREADS,
+                            mount=[self._base_name]) as session:
+                        logging.info('Pushing final image...')
+                        session.upload(result_image)
+                    return

--- a/ftl/common/cache.py
+++ b/ftl/common/cache.py
@@ -76,7 +76,6 @@ class Registry(Base):
             namespace,
             creds,
             transport,
-            cache_version=None,
             threads=1,
             should_cache=True,
             should_upload=True,
@@ -96,16 +95,15 @@ class Registry(Base):
             _reg = docker_name.Registry(_reg_name)
             self._global_creds = docker_creds.DefaultKeychain.Resolve(_reg)
         self._transport = transport
-        self._cache_version = cache_version
         self._threads = threads
         self._mount = mount or []
         self._should_cache = should_cache
         self._should_upload = should_upload
 
     def _tag(self, cache_key, repo=None):
-        fingerprint = '%s %s' % (self._base_image.digest(), cache_key)
-        if self._cache_version:
-            fingerprint += ' ' + self._cache_version
+        fingerprint = '%s %s %s' % (self._base_image.digest(),
+                                    cache_key,
+                                    constants.CACHE_KEY_VERSION)
         return docker_name.Tag('{repo}/{namespace}:{tag}'.format(
             repo=repo or str(self._repo),
             namespace=self._namespace,

--- a/ftl/common/constants.py
+++ b/ftl/common/constants.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DEFAULT_LOG_LEVEL = "NOTSET"
+DEFAULT_LOG_LEVEL = 'NOTSET'
 
 DEFAULT_DESTINATION_PATH = 'srv'
 DEFAULT_ENTRYPOINT = None
@@ -27,3 +27,16 @@ PACKAGE_LOCK = 'package-lock.json'
 PACKAGE_JSON = 'package.json'
 NODE_DEFAULT_ENTRYPOINT = 'node server.js'
 NPMRC = '.npmrc'
+
+PHASE_1_CACHE_STR = '{key_version}:{language}->{key}'
+PHASE_2_CACHE_STR = '{key_version}:{language}:{package_name}:' \
+            '{package_version}->{key}'
+CACHE_HIT = '[CACHE][HIT] '
+CACHE_MISS = '[CACHE][MISS] '
+
+PHASE_1_CACHE_HIT = CACHE_HIT + PHASE_1_CACHE_STR
+PHASE_2_CACHE_HIT = CACHE_HIT + PHASE_2_CACHE_STR
+PHASE_1_CACHE_MISS = CACHE_MISS + PHASE_1_CACHE_STR
+PHASE_2_CACHE_MISS = CACHE_MISS + PHASE_2_CACHE_STR
+
+CACHE_KEY_VERSION = 'v1'

--- a/ftl/common/ftl_util.py
+++ b/ftl/common/ftl_util.py
@@ -20,13 +20,32 @@ import tempfile
 import datetime
 import json
 
+from containerregistry.client.v2_2 import append
 from containerregistry.transform.v2_2 import metadata
+
+
+def AppendLayersIntoImage(lyr_imgs):
+    with Timing('Stitching layers into final image'):
+        for i, lyr_img in enumerate(lyr_imgs):
+            if i == 0:
+                try:
+                    result_image = lyr_img.GetImage()
+                except AttributeError:
+                    result_image = lyr_img
+                continue
+            img = lyr_img.GetImage()
+            diff_ids = img.diff_ids()
+            for diff_id in diff_ids:
+                lyr = img.blob(img._diff_id_to_digest(diff_id))
+                overrides = CfgDctToOverrides(json.loads(img.config_file()))
+                result_image = append.Layer(
+                    result_image, lyr, diff_id=diff_id, overrides=overrides)
+        return result_image
+
 
 # This is a 'whitelist' of values to pass from the
 # config_file of a DockerImage to an Overrides object
 # _OVERRIDES_VALUES = ['created', 'Entrypoint', 'Env']
-
-
 def CfgDctToOverrides(config_dct):
     """
     Takes a dct of config values and runs them through
@@ -72,13 +91,13 @@ class Timing(object):
 
 
 def zip_dir_to_layer_sha(pkg_dir):
-    tar_path = tempfile.mktemp(suffix=".tar")
-    with Timing("tar_runtime_package"):
+    tar_path = tempfile.mktemp(suffix='.tar')
+    with Timing('tar_runtime_package'):
         subprocess.check_call(['tar', '-C', pkg_dir, '-cf', tar_path, '.'])
 
     u_blob = open(tar_path, 'r').read()
     # We use gzip for performance instead of python's zip.
-    with Timing("gzip_runtime_tar"):
+    with Timing('gzip_runtime_tar'):
         subprocess.check_call(['gzip', tar_path, '-1'])
     return open(os.path.join(pkg_dir, tar_path + '.gz'), 'rb').read(), u_blob
 
@@ -98,7 +117,7 @@ def descriptor_parser(descriptor_files, ctx):
             descriptor_contents = ctx.GetFile(descriptor)
             break
     if not descriptor:
-        logging.info('No package descriptor found. No packages installed.')
+        logging.info("No package descriptor found. No packages installed.")
         return None
     return descriptor_contents
 
@@ -124,5 +143,18 @@ def creation_time(image):
 
 
 def timestamp_to_time(dt_str):
-    dt = dt_str.rstrip("Z")
+    dt = dt_str.rstrip('Z')
     return datetime.datetime.strptime(dt, "%Y-%m-%dT%H:%M:%S")
+
+
+def generate_overrides(set_path):
+    env = {
+        'VIRTUAL_ENV': '/env',
+    }
+    if set_path:
+        env['PATH'] = '/env/bin:$PATH'
+    overrides_dct = {
+        'created': str(datetime.date.today()) + 'T00:00:00Z',
+        'env': env
+    }
+    return overrides_dct

--- a/ftl/common/layer_builder.py
+++ b/ftl/common/layer_builder.py
@@ -20,6 +20,7 @@ import logging
 import subprocess
 
 from ftl.common import constants
+from ftl.common import ftl_util
 from ftl.common import single_layer_image
 from ftl.common import tar_to_dockerimage
 
@@ -38,34 +39,35 @@ class AppLayerBuilder(single_layer_image.BaseLayerBuilder):
 
     def BuildLayer(self):
         """Override."""
-        buf = cStringIO.StringIO()
-        logging.info('Starting to generate app layer \
-            tarfile from context...')
-        with tarfile.open(fileobj=buf, mode='w') as out:
-            for name in self._ctx.ListFiles():
-                content = self._ctx.GetFile(name)
-                info = tarfile.TarInfo(
-                    os.path.join(self._destination_path.strip("/"), name))
-                info.size = len(content)
-                out.addfile(info, fileobj=cStringIO.StringIO(content))
-        logging.info('Finished generating app layer tarfile from context.')
+        with ftl_util.Timing('Building app layer'):
+            buf = cStringIO.StringIO()
+            logging.info('Starting to generate app layer \
+                tarfile from context...')
+            with tarfile.open(fileobj=buf, mode='w') as out:
+                for name in self._ctx.ListFiles():
+                    content = self._ctx.GetFile(name)
+                    info = tarfile.TarInfo(
+                        os.path.join(self._destination_path.strip("/"), name))
+                    info.size = len(content)
+                    out.addfile(info, fileobj=cStringIO.StringIO(content))
+            logging.info('Finished generating app layer tarfile from context.')
 
-        tar = buf.getvalue()
+            tar = buf.getvalue()
 
-        logging.info('Starting to gzip app layer tarfile...')
-        gzip_process = subprocess.Popen(
-            ['gzip', '-f'],
-            stdout=subprocess.PIPE,
-            stdin=subprocess.PIPE,
-            stderr=subprocess.PIPE)
-        gz = gzip_process.communicate(input=tar)[0]
-        overrides_dct = {
-                'created': str(datetime.date.today()) + "T00:00:00Z"
+            logging.info('Starting to gzip app layer tarfile...')
+            gzip_process = subprocess.Popen(
+                ['gzip', '-f'],
+                stdout=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+            gz = gzip_process.communicate(input=tar)[0]
+            overrides_dct = {
+                'created': str(datetime.date.today()) + 'T00:00:00Z'
             }
-        if self._entrypoint:
-            overrides_dct['Entrypoint'] = self._entrypoint
-        if self._exposed_ports:
-            overrides_dct['ExposedPorts'] = self._exposed_ports
-        logging.info('Finished gzipping tarfile.')
-        self._img = tar_to_dockerimage.FromFSImage([gz], [tar],
-                                                   overrides_dct)
+            if self._entrypoint:
+                overrides_dct['Entrypoint'] = self._entrypoint
+            if self._exposed_ports:
+                overrides_dct['ExposedPorts'] = self._exposed_ports
+            logging.info('Finished gzipping tarfile.')
+            self._img = tar_to_dockerimage.FromFSImage([gz], [tar],
+                                                       overrides_dct)

--- a/ftl/common/logger.py
+++ b/ftl/common/logger.py
@@ -35,4 +35,4 @@ def setup_logging(args):
 def preamble(runtime, args):
     logging.info("Beginning FTL build for %s" % runtime)
     for arg in vars(args):
-        logging.info("FTL arg passed: \n %s %s" % (arg, getattr(args, arg)))
+        logging.info("FTL arg passed: %s %s" % (arg, getattr(args, arg)))

--- a/ftl/common/single_layer_image.py
+++ b/ftl/common/single_layer_image.py
@@ -16,6 +16,7 @@ building individual image layers."""
 
 import abc
 
+from ftl.common import constants
 from containerregistry.client.v2_2 import docker_digest
 
 
@@ -61,7 +62,8 @@ class CacheableLayerBuilder(BaseLayerBuilder):
         """
 
     def GetCacheKey(self):
-        return docker_digest.SHA256(self.GetCacheKeyRaw())
+        return docker_digest.SHA256("%s %s" % (self.GetCacheKeyRaw(),
+                                               constants.CACHE_KEY_VERSION))
 
     @abc.abstractmethod
     def BuildLayer(self):

--- a/ftl/node/builder.py
+++ b/ftl/node/builder.py
@@ -21,10 +21,10 @@ from ftl.node import layer_builder as node_builder
 
 
 class Node(builder.RuntimeBase):
-    def __init__(self, ctx, args, cache_version_str):
+    def __init__(self, ctx, args):
         super(
             Node, self).__init__(
-            ctx, constants.NODE_NAMESPACE, args, cache_version_str, [
+            ctx, constants.NODE_NAMESPACE, args, [
                 constants.PACKAGE_LOCK, constants.PACKAGE_JSON,
                 constants.NPMRC])
 
@@ -32,32 +32,20 @@ class Node(builder.RuntimeBase):
         lyr_imgs = []
         lyr_imgs.append(self._base_image)
         if ftl_util.has_pkg_descriptor(self._descriptor_files, self._ctx):
+            cache = self._cache if self._args.cache else None
             layer_builder = node_builder.LayerBuilder(
                 ctx=self._ctx,
                 descriptor_files=self._descriptor_files,
-                destination_path=self._args.destination_path)
-            cached_pkg_img = None
-            with ftl_util.Timing("checking cached pkg layer"):
-                key = layer_builder.GetCacheKey()
-                cached_pkg_img = self._cache.Get(key)
-            if cached_pkg_img is not None:
-                layer_builder.SetImage(cached_pkg_img)
-            else:
-                with ftl_util.Timing("building pkg layer"):
-                    layer_builder.BuildLayer()
-                with ftl_util.Timing("uploading pkg layer"):
-                    self._cache.Set(layer_builder.GetCacheKey(),
-                                    layer_builder.GetImage())
+                destination_path=self._args.destination_path,
+                cache=cache)
+            layer_builder.BuildLayer()
             lyr_imgs.append(layer_builder)
 
         app = base_builder.AppLayerBuilder(self._ctx,
                                            self._args.destination_path,
                                            self._args.entrypoint,
                                            self._args.exposed_ports)
-        with ftl_util.Timing("builder app layer"):
-            app.BuildLayer()
+        app.BuildLayer()
         lyr_imgs.append(app)
-        with ftl_util.Timing("stitching lyrs into final image"):
-            ftl_image = self.AppendLayersIntoImage(lyr_imgs)
-        with ftl_util.Timing("uploading final image"):
-            self.StoreImage(ftl_image)
+        ftl_image = ftl_util.AppendLayersIntoImage(lyr_imgs)
+        self.StoreImage(ftl_image)

--- a/ftl/node/builder_test.py
+++ b/ftl/node/builder_test.py
@@ -62,7 +62,7 @@ class NodeTest(unittest.TestCase):
         args.name = 'gcr.io/test/test:latest'
         args.base = 'gcr.io/google-appengine/python:latest'
         args.tar_base_image_path = None
-        self.builder = builder.Node(self.ctx, args, "")
+        self.builder = builder.Node(self.ctx, args)
         self.layer_builder = layer_builder.LayerBuilder(
             ctx=self.builder._ctx,
             descriptor_files=self.builder._descriptor_files,

--- a/ftl/node/layer_builder.py
+++ b/ftl/node/layer_builder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """This package implements the Node package layer builder."""
 
-
+import logging
 import os
 import subprocess
 import tempfile
@@ -27,23 +27,45 @@ from ftl.common import tar_to_dockerimage
 
 
 class LayerBuilder(single_layer_image.CacheableLayerBuilder):
-    def __init__(self, ctx=None, descriptor_files=None, pkg_descriptor=None,
-                 destination_path=constants.DEFAULT_DESTINATION_PATH):
+    def __init__(self,
+                 ctx=None,
+                 descriptor_files=None,
+                 pkg_descriptor=None,
+                 destination_path=constants.DEFAULT_DESTINATION_PATH,
+                 cache=None):
         super(LayerBuilder, self).__init__()
         self._ctx = ctx
         self._descriptor_files = descriptor_files
         self._pkg_descriptor = pkg_descriptor
         self._destination_path = destination_path
+        self._cache = cache
 
     def GetCacheKeyRaw(self):
         descriptor_contents = ftl_util.descriptor_parser(
             self._descriptor_files,
             self._ctx)
-        return "%s %s" % (descriptor_contents,
+        return '%s %s' % (descriptor_contents,
                           self._destination_path)
 
     def BuildLayer(self):
         """Override."""
+        cached_img = None
+        if self._cache:
+            with ftl_util.Timing('Checking cached pkg layer'):
+                key = self.GetCacheKey()
+                cached_img = self._cache.Get(key)
+                self._log_cache_result(False if cached_img is None else True)
+        if cached_img:
+            self.SetImage(cached_img)
+        else:
+            with ftl_util.Timing('Building pkg layer'):
+                self._build_layer()
+            if self._cache:
+                with ftl_util.Timing('Uploading pkg layer'):
+                    self._cache.Set(self.GetCacheKey(),
+                                    self.GetImage())
+
+    def _build_layer(self):
         blob, u_blob = self._gen_npm_install_tar(self._pkg_descriptor,
                                                  self._destination_path)
         self._img = tar_to_dockerimage.FromFSImage(
@@ -65,7 +87,7 @@ class LayerBuilder(single_layer_image.CacheableLayerBuilder):
             ['rm', '-rf',
                 os.path.join(app_dir, 'node_modules')])
         with ftl_util.Timing("npm_install"):
-            if pkg_descriptor is None:
+            if not pkg_descriptor:
                 subprocess.check_call(
                     ['npm', 'install', '--production'], cwd=app_dir)
             else:
@@ -93,3 +115,27 @@ class LayerBuilder(single_layer_image.CacheableLayerBuilder):
         subprocess.check_call(['npm', 'install'], cwd=app_dir, env=env)
         subprocess.check_call(
             ['npm', 'run-script', 'gcp-build'], cwd=app_dir, env=env)
+
+    def _log_cache_result(self, hit):
+        if self._pkg_descriptor:
+            if hit:
+                cache_str = constants.PHASE_2_CACHE_HIT
+            else:
+                cache_str = constants.PHASE_2_CACHE_MISS
+            logging.info(cache_str.format(
+                key_version=constants.CACHE_KEY_VERSION,
+                language='NODE',
+                package_name=self._pkg_descriptor[0],
+                package_version=self._pkg_descriptor[1],
+                key=self.GetCacheKey()
+            ))
+        else:
+            if hit:
+                cache_str = constants.PHASE_1_CACHE_HIT
+            else:
+                cache_str = constants.PHASE_1_CACHE_MISS
+            logging.info(cache_str.format(
+                key_version=constants.CACHE_KEY_VERSION,
+                language='NODE',
+                key=self.GetCacheKey()
+            ))

--- a/ftl/node/main.py
+++ b/ftl/node/main.py
@@ -33,9 +33,6 @@ node_parser = argparse.ArgumentParser(
     description='Construct node images from source.')
 args.extra_args(node_parser, args.node_flgs)
 
-# Version string used to bust caches.
-_NODE_CACHE_VERSION = 'v1'
-
 
 def main(cli_args):
     builder_args = node_parser.parse_args(cli_args)
@@ -44,8 +41,7 @@ def main(cli_args):
     with ftl_util.Timing("full build"):
         with ftl_util.Timing("builder initialization"):
             node_ftl = node_builder.Node(
-                context.Workspace(builder_args.directory), builder_args,
-                _NODE_CACHE_VERSION)
+                context.Workspace(builder_args.directory), builder_args)
         with ftl_util.Timing("build process for FTL image"):
             node_ftl.Build()
 

--- a/ftl/php/builder.py
+++ b/ftl/php/builder.py
@@ -27,8 +27,8 @@ _COMPOSER_JSON = 'composer.json'
 
 
 class PHP(builder.RuntimeBase):
-    def __init__(self, ctx, args, cache_version_str):
-        super(PHP, self).__init__(ctx, _PHP_NAMESPACE, args, cache_version_str,
+    def __init__(self, ctx, args):
+        super(PHP, self).__init__(ctx, _PHP_NAMESPACE, args,
                                   [_COMPOSER_LOCK, _COMPOSER_JSON])
 
     def _parse_composer_pkgs(self):
@@ -49,25 +49,16 @@ class PHP(builder.RuntimeBase):
             if len(pkgs) > 41:
                 pkgs = [None]
             for pkg_txt in pkgs:
-                logging.info('building package layer')
+                logging.info('Building package layer')
                 logging.info(pkg_txt)
+                cache = self._cache if self._args.cache else None
                 layer_builder = php_builder.LayerBuilder(
                     ctx=self._ctx,
                     descriptor_files=self._descriptor_files,
                     pkg_descriptor=pkg_txt,
-                    destination_path=self._args.destination_path)
-                cached_pkg_img = None
-                with ftl_util.Timing("checking cached pkg layer"):
-                    key = layer_builder.GetCacheKey()
-                    cached_pkg_img = self._cache.Get(key)
-                if cached_pkg_img is not None:
-                    layer_builder.SetImage(cached_pkg_img)
-                else:
-                    with ftl_util.Timing("building pkg layer"):
-                        layer_builder.BuildLayer()
-                        with ftl_util.Timing("uploading pkg layer"):
-                            self._cache.Set(layer_builder.GetCacheKey(),
-                                            layer_builder.GetImage())
+                    destination_path=self._args.destination_path,
+                    cache=cache)
+                layer_builder.BuildLayer()
                 lyr_imgs.append(layer_builder)
 
         app = base_builder.AppLayerBuilder(
@@ -75,10 +66,7 @@ class PHP(builder.RuntimeBase):
             destination_path=self._args.destination_path,
             entrypoint=self._args.entrypoint,
             exposed_ports=self._args.exposed_ports)
-        with ftl_util.Timing("builder app layer"):
-            app.BuildLayer()
+        app.BuildLayer()
         lyr_imgs.append(app)
-        with ftl_util.Timing("stitching lyrs into final image"):
-            ftl_image = self.AppendLayersIntoImage(lyr_imgs)
-        with ftl_util.Timing("uploading final image"):
-            self.StoreImage(ftl_image)
+        ftl_image = ftl_util.AppendLayersIntoImage(lyr_imgs)
+        self.StoreImage(ftl_image)

--- a/ftl/php/builder_test.py
+++ b/ftl/php/builder_test.py
@@ -73,7 +73,7 @@ class PHPTest(unittest.TestCase):
         args.name = 'gcr.io/test/test:latest'
         args.base = 'gcr.io/google-appengine/php:latest'
         args.tar_base_image_path = None
-        self.builder = builder.PHP(self.ctx, args, "")
+        self.builder = builder.PHP(self.ctx, args)
         self.layer_builder = layer_builder.LayerBuilder(
             self.builder._ctx, None, self.builder._descriptor_files, "/app")
 

--- a/ftl/php/layer_builder.py
+++ b/ftl/php/layer_builder.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """This package implements the PHP package layer builder."""
 
+import logging
 import os
 import subprocess
 import tempfile
@@ -29,15 +30,17 @@ class LayerBuilder(single_layer_image.CacheableLayerBuilder):
                  ctx=None,
                  descriptor_files=None,
                  pkg_descriptor=None,
-                 destination_path=constants.DEFAULT_DESTINATION_PATH):
+                 destination_path=constants.DEFAULT_DESTINATION_PATH,
+                 cache=None):
         super(LayerBuilder, self).__init__()
         self._ctx = ctx
         self._descriptor_files = descriptor_files
         self._pkg_descriptor = pkg_descriptor
         self._destination_path = destination_path
+        self._cache = cache
 
     def GetCacheKeyRaw(self):
-        if self._pkg_descriptor is not None:
+        if self._pkg_descriptor:
             # phase 2 cache key
             return "%s %s %s" % (self._pkg_descriptor[0],
                                  self._pkg_descriptor[1],
@@ -49,9 +52,26 @@ class LayerBuilder(single_layer_image.CacheableLayerBuilder):
 
     def BuildLayer(self):
         """Override."""
+        cached_img = None
+        if self._cache:
+            with ftl_util.Timing('Checking cached pkg layer'):
+                key = self.GetCacheKey()
+                cached_img = self._cache.Get(key)
+                self._log_cache_result(False if cached_img is None else True)
+        if cached_img:
+            self.SetImage(cached_img)
+        else:
+            with ftl_util.Timing('Building pkg layer'):
+                self._build_layer()
+            if self._cache:
+                with ftl_util.Timing('Uploading pkg layer'):
+                    self._cache.Set(self.GetCacheKey(),
+                                    self.GetImage())
+
+    def _build_layer(self):
         blob, u_blob = self._gen_composer_install_tar(self._pkg_descriptor,
                                                       self._destination_path)
-        overrides_dct = {'created': str(datetime.date.today()) + "T00:00:00Z"}
+        overrides_dct = {'created': str(datetime.date.today()) + 'T00:00:00Z'}
         self._img = tar_to_dockerimage.FromFSImage([blob], [u_blob],
                                                    overrides_dct)
 
@@ -59,19 +79,18 @@ class LayerBuilder(single_layer_image.CacheableLayerBuilder):
         # Create temp directory to write package descriptor to
         pkg_dir = tempfile.mkdtemp()
         app_dir = os.path.join(pkg_dir, destination_path.strip("/"))
-        print 'app_dir: %s' % app_dir
         os.makedirs(app_dir)
 
         # Copy out the relevant package descriptors to a tempdir.
-        if pkg_descriptor is None:
+        if not pkg_descriptor:
             # phase 1 copy whole descriptor
             ftl_util.descriptor_copy(self._ctx, self._descriptor_files,
                                      app_dir)
 
         subprocess.check_call(['rm', '-rf', os.path.join(app_dir, 'vendor')])
 
-        with ftl_util.Timing("composer_install"):
-            if pkg_descriptor is None:
+        with ftl_util.Timing('Composer_install'):
+            if not pkg_descriptor:
                 # phase 1 install entire descriptor
                 subprocess.check_call(
                     ['composer', 'install', '--no-dev', '--no-scripts'],
@@ -83,3 +102,27 @@ class LayerBuilder(single_layer_image.CacheableLayerBuilder):
                      str(pkg), str(version)],
                     cwd=app_dir)
         return ftl_util.zip_dir_to_layer_sha(pkg_dir)
+
+    def _log_cache_result(self, hit):
+        if self._pkg_descriptor:
+            if hit:
+                cache_str = constants.PHASE_2_CACHE_HIT
+            else:
+                cache_str = constants.PHASE_2_CACHE_MISS
+            logging.info(cache_str.format(
+                key_version=constants.CACHE_KEY_VERSION,
+                language='PHP',
+                package_name=self._pkg_descriptor[0],
+                package_version=self._pkg_descriptor[1],
+                key=self.GetCacheKey()
+            ))
+        else:
+            if hit:
+                cache_str = constants.PHASE_1_CACHE_HIT
+            else:
+                cache_str = constants.PHASE_1_CACHE_MISS
+            logging.info(cache_str.format(
+                key_version=constants.CACHE_KEY_VERSION,
+                language='PHP',
+                key=self.GetCacheKey()
+            ))

--- a/ftl/php/main.py
+++ b/ftl/php/main.py
@@ -32,9 +32,6 @@ php_parser = argparse.ArgumentParser(
     description='Construct php images from source.')
 args.extra_args(php_parser, args.php_flgs)
 
-# Version string used to bust caches.
-_PHP_CACHE_VERSION = 'v1'
-
 
 def main(cli_args):
     builder_args = php_parser.parse_args(cli_args)
@@ -43,8 +40,7 @@ def main(cli_args):
     with ftl_util.Timing("full build"):
         with ftl_util.Timing("builder initialization"):
             php_ftl = php_builder.PHP(
-                context.Workspace(builder_args.directory), builder_args,
-                _PHP_CACHE_VERSION)
+                context.Workspace(builder_args.directory), builder_args)
         with ftl_util.Timing("build process for FTL image"):
             php_ftl.Build()
 

--- a/ftl/python/builder.py
+++ b/ftl/python/builder.py
@@ -13,11 +13,6 @@
 # limitations under the License.
 """This package defines the interface for orchestrating image builds."""
 
-import logging
-import os
-import subprocess
-import tempfile
-
 from ftl.common import builder
 from ftl.common import ftl_util
 from ftl.common import layer_builder as base_builder
@@ -31,9 +26,9 @@ _PYTHON_NAMESPACE = 'python-requirements-cache'
 
 
 class Python(builder.RuntimeBase):
-    def __init__(self, ctx, args, cache_version_str):
-        super(Python, self).__init__(ctx, _PYTHON_NAMESPACE, args,
-                                     cache_version_str, [_REQUIREMENTS_TXT])
+    def __init__(self, ctx, args):
+        super(Python, self).__init__(ctx, _PYTHON_NAMESPACE,
+                                     args, [_REQUIREMENTS_TXT])
         self._venv_dir = ftl_util.gen_tmp_dir(_VENV_DIR)
         self._wheel_dir = ftl_util.gen_tmp_dir(_WHEEL_DIR)
         self._python_cmd = args.python_cmd.split(" ")
@@ -44,151 +39,38 @@ class Python(builder.RuntimeBase):
         lyr_imgs = []
         lyr_imgs.append(self._base_image)
 
+        cache = self._cache if self._args.cache else None
+
         if ftl_util.has_pkg_descriptor(self._descriptor_files, self._ctx):
-            # check cache or build interpreter layer
+            # build interpreter layer
             interpreter_builder = package_builder.InterpreterLayerBuilder(
-                self._venv_dir, self._python_cmd, self._venv_cmd)
-            cached_int_img = None
-            with ftl_util.Timing("checking cached int layer"):
-                key = interpreter_builder.GetCacheKey()
-                cached_int_img = self._cache.Get(key)
-            if cached_int_img is not None:
-                interpreter_builder.SetImage(cached_int_img)
-            else:
-                with ftl_util.Timing("building interpreter layer"):
-                    interpreter_builder.BuildLayer()
-                with ftl_util.Timing("uploading int layer"):
-                    self._cache.Set(interpreter_builder.GetCacheKey(),
-                                    interpreter_builder.GetImage())
+                venv_dir=self._venv_dir,
+                python_cmd=self._python_cmd,
+                venv_cmd=self._venv_cmd,
+                cache=cache)
+            interpreter_builder.BuildLayer()
             lyr_imgs.append(interpreter_builder)
 
-            # check cache or build package layers
-            req_txt_builder = package_builder.PackageLayerBuilder(
-                self._ctx, self._descriptor_files, None,
-                interpreter_builder)
-            cached_req_txt_img = None
-            with ftl_util.Timing("checking cached req.txt layer"):
-                key = req_txt_builder.GetCacheKey()
-                cached_req_txt_img = self._cache.Get(key)
-            if cached_req_txt_img is not None:
-                req_txt_builder.SetImage(cached_req_txt_img)
-            else:
-                with ftl_util.Timing("installing pip packages"):
-                    pkg_descriptor = ftl_util.descriptor_parser(
-                        self._descriptor_files, self._ctx)
-                    self._pip_install(pkg_descriptor)
-
-                with ftl_util.Timing("resolving whl paths"):
-                    whls = self._resolve_whls()
-                    pkg_dirs = [self._whl_to_fslayer(whl) for whl in whls]
-
-                req_txt_imgs = []
-                for whl_pkg_dir in pkg_dirs:
-                    layer_builder = package_builder.PackageLayerBuilder(
-                        self._ctx, self._descriptor_files, whl_pkg_dir,
-                        interpreter_builder)
-                    with ftl_util.Timing("building pkg layer"):
-                        layer_builder.BuildLayer()
-                    req_txt_imgs.append(layer_builder)
-
-                with ftl_util.Timing("stitching lyrs into req.txt image"):
-                    req_txt_image = self.AppendLayersIntoImage(req_txt_imgs)
-
-                req_txt_builder.SetImage(req_txt_image)
-                with ftl_util.Timing("uploading req.txt image"):
-                    self._cache.Set(req_txt_builder.GetCacheKey(),
-                                    req_txt_builder.GetImage())
+            # build package layers
+            req_txt_builder = package_builder.RequirementsLayerBuilder(
+                ctx=self._ctx,
+                descriptor_files=self._descriptor_files,
+                pkg_dir=None,
+                wheel_dir=self._wheel_dir,
+                venv_dir=self._venv_dir,
+                pip_cmd=self._pip_cmd,
+                venv_cmd=self._venv_cmd,
+                dep_img_lyr=interpreter_builder,
+                cache=cache)
+            req_txt_builder.BuildLayer()
             lyr_imgs.append(req_txt_builder)
-
-            with ftl_util.Timing("resolving whl paths"):
-                whls = self._resolve_whls()
-                pkg_dirs = [self._whl_to_fslayer(whl) for whl in whls]
-            for whl_pkg_dir in pkg_dirs:
-                layer_builder = package_builder.PackageLayerBuilder(
-                    self._ctx, self._descriptor_files, whl_pkg_dir,
-                    interpreter_builder)
-                cached_pkg_img = None
-                with ftl_util.Timing("checking cached pkg layer"):
-                    key = layer_builder.GetCacheKey()
-                    cached_pkg_img = self._cache.Get(key)
-                if cached_pkg_img is not None:
-                    layer_builder.SetImage(cached_pkg_img)
-                else:
-                    with ftl_util.Timing("building pkg layer"):
-                        layer_builder.BuildLayer()
-                    with ftl_util.Timing("uploading pkg layer"):
-                        self._cache.Set(layer_builder.GetCacheKey(),
-                                        layer_builder.GetImage())
-                lyr_imgs.append(layer_builder)
 
         app = base_builder.AppLayerBuilder(
             ctx=self._ctx,
             destination_path=self._args.destination_path,
             entrypoint=self._args.entrypoint,
             exposed_ports=self._args.exposed_ports)
-        with ftl_util.Timing("building app layer"):
-            app.BuildLayer()
+        app.BuildLayer()
         lyr_imgs.append(app)
-        with ftl_util.Timing("stitching lyrs into final image"):
-            ftl_image = self.AppendLayersIntoImage(lyr_imgs)
-        with ftl_util.Timing("uploading final image"):
-            self.StoreImage(ftl_image)
-
-    def _pip_install(self, pkg_txt):
-        with ftl_util.Timing("pip_download_wheels"):
-            pip_cmd_args = list(self._pip_cmd)
-            pip_cmd_args.extend(
-                ['wheel', '-w', self._wheel_dir, '-r', "/dev/stdin"])
-
-            proc_pipe = subprocess.Popen(
-                pip_cmd_args,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=self._gen_pip_env(),
-            )
-            stdout, stderr = proc_pipe.communicate(input=pkg_txt)
-            logging.info("`pip wheel` stdout:\n%s" % stdout)
-            if stderr:
-                logging.error("`pip wheel` had error output:\n%s" % stderr)
-            if proc_pipe.returncode:
-                raise Exception("error: `pip wheel` returned code: %d" %
-                                proc_pipe.returncode)
-
-    def _resolve_whls(self):
-        return [
-            os.path.join(self._wheel_dir, f)
-            for f in os.listdir(self._wheel_dir)
-        ]
-
-    def _whl_to_fslayer(self, whl):
-        tmp_dir = tempfile.mkdtemp()
-        pkg_dir = os.path.join(tmp_dir, 'env')
-        os.makedirs(pkg_dir)
-
-        pip_cmd_args = list(self._pip_cmd)
-        pip_cmd_args.extend(['install', '--no-deps', '--prefix', pkg_dir, whl])
-
-        proc_pipe = subprocess.Popen(
-            pip_cmd_args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=self._gen_pip_env(),
-        )
-        stdout, stderr = proc_pipe.communicate()
-        logging.info("`pip install` stdout:\n%s" % stdout)
-        if stderr:
-            logging.error("`pip install` had error output:\n%s" % stderr)
-        if proc_pipe.returncode:
-            raise Exception("error: `pip install` returned code: %d" %
-                            proc_pipe.returncode)
-        return tmp_dir
-
-    def _gen_pip_env(self):
-        pip_env = os.environ.copy()
-        # bazel adds its own PYTHONPATH to the env
-        # which must be removed for the pip calls to work properly
-        pip_env.pop('PYTHONPATH', None)
-        pip_env['VIRTUAL_ENV'] = self._venv_dir
-        pip_env['PATH'] = self._venv_dir + "/bin" + ":" + os.environ['PATH']
-        return pip_env
+        ftl_image = ftl_util.AppendLayersIntoImage(lyr_imgs)
+        self.StoreImage(ftl_image)

--- a/ftl/python/builder_test.py
+++ b/ftl/python/builder_test.py
@@ -56,7 +56,7 @@ class PythonTest(unittest.TestCase):
         args.pip_cmd = 'pip'
         args.venv_cmd = 'virtualenv'
         args.tar_base_image_path = None
-        self.builder = builder.Python(self.ctx, args, "")
+        self.builder = builder.Python(self.ctx, args)
         self.interpreter_builder = layer_builder.InterpreterLayerBuilder(
             self.builder._venv_dir, self.builder._python_cmd,
             self.builder._venv_cmd)

--- a/ftl/python/layer_builder.py
+++ b/ftl/python/layer_builder.py
@@ -13,55 +13,238 @@
 # limitations under the License.
 """This package implements the Python package layer builder."""
 
-import datetime
+import logging
 import os
 import subprocess
-import logging
+import tempfile
 
+from ftl.common import constants
 from ftl.common import ftl_util
 from ftl.common import single_layer_image
 from ftl.common import tar_to_dockerimage
 
 
 class PackageLayerBuilder(single_layer_image.CacheableLayerBuilder):
-    def __init__(self, ctx, descriptor_files, pkg_dir, dep_img_lyr):
+    def __init__(self, ctx=None, descriptor_files=None,
+                 pkg_dir=None, dep_img_lyr=None, cache=None):
         super(PackageLayerBuilder, self).__init__()
         self._ctx = ctx
         self._pkg_dir = pkg_dir
         self._descriptor_files = descriptor_files
         self._dep_img_lyr = dep_img_lyr
+        self._cache = cache
 
     def GetCacheKeyRaw(self):
         descriptor_contents = ftl_util.descriptor_parser(
             self._descriptor_files, self._ctx)
-        return "%s %s" % (descriptor_contents,
+        return '%s %s' % (descriptor_contents,
                           self._dep_img_lyr.GetCacheKeyRaw())
 
     def BuildLayer(self):
+        cached_img = None
+        if self._cache:
+            with ftl_util.Timing('Checking cached pkg layer'):
+                key = self.GetCacheKey()
+                cached_img = self._cache.Get(key)
+                self._log_cache_result(False if cached_img is None else True)
+        if cached_img:
+            self.SetImage(cached_img)
+        else:
+            with ftl_util.Timing('Building pkg layer'):
+                self._build_layer()
+            if self._cache:
+                with ftl_util.Timing('Uploading pkg layer'):
+                    self._cache.Set(self.GetCacheKey(),
+                                    self.GetImage())
+
+    def _build_layer(self):
         blob, u_blob = ftl_util.zip_dir_to_layer_sha(self._pkg_dir)
+        overrides = ftl_util.generate_overrides(False)
         self._img = tar_to_dockerimage.FromFSImage([blob], [u_blob],
-                                                   _generate_overrides(False))
+                                                   overrides)
+
+    def _log_cache_result(self, hit):
+        if hit:
+            cache_str = constants.PHASE_1_CACHE_HIT
+        else:
+            cache_str = constants.PHASE_1_CACHE_MISS
+        logging.info(cache_str.format(
+            key_version=constants.CACHE_KEY_VERSION,
+            language='PYTHON (package)',
+            key=self.GetCacheKey()
+        ))
+
+
+class RequirementsLayerBuilder(single_layer_image.CacheableLayerBuilder):
+    def __init__(self, ctx=None, descriptor_files=None, pkg_dir=None,
+                 dep_img_lyr=None, wheel_dir=None, venv_dir=None,
+                 pip_cmd=None, venv_cmd=None, cache=None):
+        super(RequirementsLayerBuilder, self).__init__()
+        self._ctx = ctx
+        self._pkg_dir = pkg_dir
+        self._wheel_dir = wheel_dir
+        self._venv_dir = venv_dir
+        self._pip_cmd = pip_cmd
+        self._venv_cmd = venv_cmd
+        self._descriptor_files = descriptor_files
+        self._dep_img_lyr = dep_img_lyr
+        self._cache = cache
+
+    def GetCacheKeyRaw(self):
+        descriptor_contents = ftl_util.descriptor_parser(
+            self._descriptor_files, self._ctx)
+        return '%s %s' % (descriptor_contents,
+                          self._dep_img_lyr.GetCacheKeyRaw())
+
+    def BuildLayer(self):
+        cached_img = None
+        if self._cache:
+            with ftl_util.Timing('Checking cached req.txt layer'):
+                key = self.GetCacheKey()
+                cached_img = self._cache.Get(key)
+                self._log_cache_result(False if cached_img is None else True)
+        if cached_img:
+            self.SetImage(cached_img)
+        else:
+            with ftl_util.Timing('Installing pip packages'):
+                pkg_descriptor = ftl_util.descriptor_parser(
+                    self._descriptor_files, self._ctx)
+                self._pip_install(pkg_descriptor)
+
+            with ftl_util.Timing('Resolving whl paths'):
+                whls = self._resolve_whls()
+                pkg_dirs = [self._whl_to_fslayer(whl) for whl in whls]
+
+            req_txt_imgs = []
+            for whl_pkg_dir in pkg_dirs:
+                layer_builder = PackageLayerBuilder(
+                    ctx=self._ctx,
+                    descriptor_files=self._descriptor_files,
+                    pkg_dir=whl_pkg_dir,
+                    dep_img_lyr=self,
+                    cache=self._cache)
+                layer_builder.BuildLayer()
+                req_txt_imgs.append(layer_builder)
+
+            req_txt_image = ftl_util.AppendLayersIntoImage(req_txt_imgs)
+
+            self.SetImage(req_txt_image)
+
+            if self._cache:
+                with ftl_util.Timing('Uploading req.txt image'):
+                    self._cache.Set(self.GetCacheKey(),
+                                    self.GetImage())
+
+    def _resolve_whls(self):
+        return [
+            os.path.join(self._wheel_dir, f)
+            for f in os.listdir(self._wheel_dir)
+        ]
+
+    def _whl_to_fslayer(self, whl):
+        tmp_dir = tempfile.mkdtemp()
+        pkg_dir = os.path.join(tmp_dir, 'env')
+        os.makedirs(pkg_dir)
+
+        pip_cmd_args = list(self._pip_cmd)
+        pip_cmd_args.extend(['install', '--no-deps', '--prefix', pkg_dir, whl])
+
+        proc_pipe = subprocess.Popen(
+            pip_cmd_args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self._gen_pip_env(),
+        )
+        stdout, stderr = proc_pipe.communicate()
+        logging.info("`pip install` stdout:\n%s" % stdout)
+        if stderr:
+            logging.error("`pip install` had error output:\n%s" % stderr)
+        if proc_pipe.returncode:
+            raise Exception("error: `pip install` returned code: %d" %
+                            proc_pipe.returncode)
+        return tmp_dir
+
+    def _pip_install(self, pkg_txt):
+        with ftl_util.Timing('pip_download_wheels'):
+            pip_cmd_args = list(self._pip_cmd)
+            pip_cmd_args.extend(
+                ['wheel', '-w', self._wheel_dir, '-r', '/dev/stdin'])
+
+            proc_pipe = subprocess.Popen(
+                pip_cmd_args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=self._gen_pip_env(),
+            )
+            stdout, stderr = proc_pipe.communicate(input=pkg_txt)
+            logging.info("`pip wheel` stdout:\n%s" % stdout)
+            if stderr:
+                logging.error("`pip wheel` had error output:\n%s" % stderr)
+            if proc_pipe.returncode:
+                raise Exception("error: `pip wheel` returned code: %d" %
+                                proc_pipe.returncode)
+
+    def _gen_pip_env(self):
+        pip_env = os.environ.copy()
+        # bazel adds its own PYTHONPATH to the env
+        # which must be removed for the pip calls to work properly
+        pip_env.pop('PYTHONPATH', None)
+        pip_env['VIRTUAL_ENV'] = self._venv_dir
+        pip_env['PATH'] = self._venv_dir + '/bin' + ':' + os.environ['PATH']
+        return pip_env
+
+    def _log_cache_result(self, hit):
+        if hit:
+            cache_str = constants.PHASE_1_CACHE_HIT
+        else:
+            cache_str = constants.PHASE_1_CACHE_MISS
+        logging.info(cache_str.format(
+            key_version=constants.CACHE_KEY_VERSION,
+            language='PYTHON (requirements)',
+            key=self.GetCacheKey()
+        ))
 
 
 class InterpreterLayerBuilder(single_layer_image.CacheableLayerBuilder):
-    def __init__(self, venv_dir, python_cmd, venv_cmd):
+    def __init__(self, venv_dir=None, python_cmd=None,
+                 venv_cmd=None, cache=None):
         super(InterpreterLayerBuilder, self).__init__()
         self._venv_dir = venv_dir
         self._python_cmd = python_cmd
         self._venv_cmd = venv_cmd
+        self._cache = cache
 
     def GetCacheKeyRaw(self):
-        return "%s %s" % (self._python_cmd, self._venv_cmd)
+        return '%s %s' % (self._python_cmd, self._venv_cmd)
 
     def BuildLayer(self):
+        cached_img = None
+        if self._cache:
+            with ftl_util.Timing('Checking cached pkg layer'):
+                key = self.GetCacheKey()
+                cached_img = self._cache.Get(key)
+                self._log_cache_result(False if cached_img is None else True)
+        if cached_img:
+            self.SetImage(cached_img)
+        else:
+            with ftl_util.Timing('Building pkg layer'):
+                self._build_layer()
+            if self._cache:
+                with ftl_util.Timing('Uploading pkg layer'):
+                    self._cache.Set(self.GetCacheKey(),
+                                    self.GetImage())
+
+    def _build_layer(self):
         self._setup_venv()
         blob, u_blob = ftl_util.zip_dir_to_layer_sha(
             os.path.abspath(os.path.join(self._venv_dir, os.pardir)))
+        overrides = ftl_util.generate_overrides(True)
         self._img = tar_to_dockerimage.FromFSImage([blob], [u_blob],
-                                                   _generate_overrides(True))
+                                                   overrides)
 
     def _setup_venv(self):
-        with ftl_util.Timing("create_virtualenv"):
+        with ftl_util.Timing('create_virtualenv'):
             venv_cmd_args = list(self._venv_cmd)
             venv_cmd_args.extend([
                 '--no-download',
@@ -86,15 +269,13 @@ class InterpreterLayerBuilder(single_layer_image.CacheableLayerBuilder):
 
             subprocess.check_call(venv_cmd_args)
 
-
-def _generate_overrides(set_path):
-    env = {
-        "VIRTUAL_ENV": "/env",
-    }
-    if set_path:
-        env['PATH'] = '/env/bin:$PATH'
-    overrides_dct = {
-        "created": str(datetime.date.today()) + "T00:00:00Z",
-        "env": env
-    }
-    return overrides_dct
+    def _log_cache_result(self, hit):
+        if hit:
+            cache_str = constants.PHASE_1_CACHE_HIT
+        else:
+            cache_str = constants.PHASE_1_CACHE_MISS
+        logging.info(cache_str.format(
+            key_version=constants.CACHE_KEY_VERSION,
+            language='PYTHON (interpreter)',
+            key=self.GetCacheKey()
+        ))

--- a/ftl/python/main.py
+++ b/ftl/python/main.py
@@ -32,9 +32,6 @@ python_parser = argparse.ArgumentParser(
     description='Construct python images from source.')
 args.extra_args(python_parser, args.python_flgs)
 
-# Version string used to bust caches.
-_PYTHON_CACHE_VERSION = 'v1'
-
 
 def main(cli_args):
     builder_args = python_parser.parse_args(cli_args)
@@ -44,9 +41,7 @@ def main(cli_args):
         with ftl_util.Timing("builder initialization"):
             python_ftl = python_builder.Python(
                 context.Workspace(builder_args.directory),
-                builder_args,
-                _PYTHON_CACHE_VERSION,
-            )
+                builder_args)
         with ftl_util.Timing("build process for FTL image"):
             python_ftl.Build()
 

--- a/test.sh
+++ b/test.sh
@@ -16,6 +16,6 @@ pushd appengine/runtime_builders && py.test test_manifest.py && popd
 
 # Check building of container related tools
 bazel run //:gazelle
-bazel build docgen/scripts/docgen:docgen
-bazel build versioning/scripts/dockerfiles:dockerfiles
-bazel build versioning/scripts/cloudbuild:cloudbuild
+bazel build //docgen/scripts/docgen:docgen
+bazel build //versioning/scripts/dockerfiles:dockerfiles
+bazel build //versioning/scripts/cloudbuild:cloudbuild

--- a/testing/lib/BUILD
+++ b/testing/lib/BUILD
@@ -24,7 +24,10 @@ py_library(
     srcs = glob([
         "*.py",
     ]),
-    deps = ["@containerregistry"],
+    deps = [
+        "@containerregistry",
+        "@mock",
+    ],
 )
 
 docker_build(
@@ -36,5 +39,8 @@ py_test(
     name = "mock_registry_tests",
     srcs = ["mock_registry_tests.py"],
     data = [":test.tar"],
-    deps = ["@containerregistry"],
+    deps = [
+        "@containerregistry",
+        "@mock",
+    ],
 )

--- a/vendor/github.com/ghodss/yaml/BUILD.bazel
+++ b/vendor/github.com/ghodss/yaml/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "fields.go",
+        "yaml.go",
+    ],
+    importpath = "github.com/ghodss/yaml",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/gopkg.in/yaml.v2:go_default_library"],
+)

--- a/vendor/github.com/golang/protobuf/jsonpb/BUILD.bazel
+++ b/vendor/github.com/golang/protobuf/jsonpb/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["jsonpb.go"],
+    importpath = "github.com/golang/protobuf/jsonpb",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/golang/protobuf/proto:go_default_library",
+        "//vendor/github.com/golang/protobuf/ptypes/struct:go_default_library",
+    ],
+)

--- a/vendor/github.com/golang/protobuf/proto/BUILD.bazel
+++ b/vendor/github.com/golang/protobuf/proto/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "clone.go",
+        "decode.go",
+        "discard.go",
+        "encode.go",
+        "equal.go",
+        "extensions.go",
+        "lib.go",
+        "message_set.go",
+        "pointer_unsafe.go",
+        "properties.go",
+        "text.go",
+        "text_parser.go",
+    ],
+    importpath = "github.com/golang/protobuf/proto",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/golang/protobuf/ptypes/struct/BUILD.bazel
+++ b/vendor/github.com/golang/protobuf/ptypes/struct/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+proto_library(
+    name = "structpb_proto",
+    srcs = ["struct.proto"],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "structpb_go_proto",
+    importpath = "github.com/golang/protobuf/ptypes/struct",
+    proto = ":structpb_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":structpb_go_proto"],
+    importpath = "github.com/golang/protobuf/ptypes/struct",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/gopkg.in/yaml.v2/BUILD.bazel
+++ b/vendor/gopkg.in/yaml.v2/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "apic.go",
+        "decode.go",
+        "emitterc.go",
+        "encode.go",
+        "parserc.go",
+        "readerc.go",
+        "resolve.go",
+        "scannerc.go",
+        "sorter.go",
+        "writerc.go",
+        "yaml.go",
+        "yamlh.go",
+        "yamlprivateh.go",
+    ],
+    importpath = "gopkg.in/yaml.v2",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This code adds logging for all cache gets and sets done by the layer builders when constructing the package layers. This will allow us to track hits and misses, and also track the cache key mappings.

Additionally, this factors out all the logic done by the top-level language builders into the layer builders themselves. The language builders now just drive the high-level assembly of the final images, while the layer builders are responsible for actually installing packages, constructing the layers, and interacting with the cache.