### PR TITLE
Only compute digest of cache key once, and remove base image from key

### DIFF
--- a/ftl/common/builder.py
+++ b/ftl/common/builder.py
@@ -96,7 +96,6 @@ class RuntimeBase(JustApp):
         self._cache = cache.Registry(
             repo=cache_repo,
             namespace=self._namespace,
-            base_image=self._base_image,
             creds=self._target_creds,
             transport=self._transport,
             threads=constants.THREADS,

--- a/ftl/common/cache.py
+++ b/ftl/common/cache.py
@@ -14,7 +14,6 @@
 """This package defines the interface for caching objects."""
 
 import abc
-import hashlib
 import logging
 import datetime
 
@@ -46,7 +45,6 @@ class Base(object):
     def Get(self, cache_key):
         """Lookup a cached image.
         Args:
-          base_image: the docker_image.Image on which things are based.
           cache_key: the cache_key of the package descriptor atop our base.
         Returns:
           the docker_image.Image of the cache hit, or None.
@@ -56,7 +54,6 @@ class Base(object):
     def Set(self, cache_key, value):
         """Set an entry in the cache.
         Args:
-          base_image: the docker_image.Image on which things are based.
           cache_key: the cache_key of the package descriptor atop our base.
           value: the docker_image.Image to store into the cache.
         """
@@ -72,7 +69,6 @@ class Registry(Base):
     def __init__(
             self,
             repo,
-            base_image,
             namespace,
             creds,
             transport,
@@ -84,7 +80,6 @@ class Registry(Base):
     ):
         super(Registry, self).__init__()
         self._repo = repo
-        self._base_image = base_image
         self._namespace = namespace
         self._creds = creds
         _reg_name = '{base}/{namespace}'.format(
@@ -101,12 +96,10 @@ class Registry(Base):
         self._should_upload = should_upload
 
     def _tag(self, cache_key, repo=None):
-        fingerprint = '%s %s %s' % (self._base_image.digest(), cache_key,
-                                    constants.CACHE_KEY_VERSION)
         return docker_name.Tag('{repo}/{namespace}:{tag}'.format(
             repo=repo or str(self._repo),
             namespace=self._namespace,
-            tag=hashlib.sha256(fingerprint).hexdigest()))
+            tag=cache_key))
 
     def Get(self, cache_key):
         if not self._should_cache:

--- a/ftl/common/cache_test.py
+++ b/ftl/common/cache_test.py
@@ -37,7 +37,6 @@ class RegistryTest(unittest.TestCase):
         mock_img.exists.return_value = True
         c = cache.Registry(
             repo='fake.gcr.io/google-appengine',
-            base_image=fake_base,
             namespace='namespace',
             creds=None,
             transport=None)
@@ -47,7 +46,6 @@ class RegistryTest(unittest.TestCase):
         mock_img.exists.return_value = False
         c = cache.Registry(
             repo='fake.gcr.io/google-appengine',
-            base_image=fake_base,
             namespace='namespace',
             creds=None,
             transport=None)

--- a/ftl/common/single_layer_image.py
+++ b/ftl/common/single_layer_image.py
@@ -15,9 +15,9 @@
 building individual image layers."""
 
 import abc
+import hashlib
 
 from ftl.common import constants
-from containerregistry.client.v2_2 import docker_digest
 
 
 class BaseLayerBuilder(object):
@@ -62,8 +62,9 @@ class CacheableLayerBuilder(BaseLayerBuilder):
         """
 
     def GetCacheKey(self):
-        return docker_digest.SHA256("%s %s" % (self.GetCacheKeyRaw(),
-                                               constants.CACHE_KEY_VERSION))
+        fingerprint = "%s %s" % (self.GetCacheKeyRaw(),
+                                 constants.CACHE_KEY_VERSION)
+        return hashlib.sha256(fingerprint).hexdigest()
 
     @abc.abstractmethod
     def BuildLayer(self):


### PR DESCRIPTION
No base image is actually used when building the package layers, so we shouldn't be embedding any base image in the keys.

I think (?) this will break any active local caches until the images expire, but I'm not sure this matters much. @aaron-prindle can you confirm