### PR TITLE
fix venv dir path

### DIFF
--- a/ftl/common/constants.py
+++ b/ftl/common/constants.py
@@ -36,7 +36,7 @@ PIPFILE_LOCK = 'Pipfile.lock'
 PIPFILE = 'Pipfile'
 REQUIREMENTS_TXT = 'requirements.txt'
 PYTHON_NAMESPACE = 'python-requirements-cache'
-VENV_DIR = 'env'
+VENV_DIR = '/env'
 WHEEL_DIR = 'wheel'
 
 # logging constants

--- a/ftl/python/builder.py
+++ b/ftl/python/builder.py
@@ -33,7 +33,7 @@ class Python(builder.RuntimeBase):
                 constants.PIPFILE,  # not supported rn
                 constants.REQUIREMENTS_TXT
             ])
-        self._venv_dir = ftl_util.gen_tmp_dir(constants.VENV_DIR)
+        self._venv_dir = constants.VENV_DIR
         self._wheel_dir = ftl_util.gen_tmp_dir(constants.WHEEL_DIR)
         self._python_cmd = args.python_cmd.split(" ")
         self._pip_cmd = args.pip_cmd.split(" ")

--- a/ftl/python/builder_test.py
+++ b/ftl/python/builder_test.py
@@ -18,6 +18,7 @@ import mock
 import json
 
 from ftl.common import context
+from ftl.common import constants
 from ftl.common import ftl_util
 from ftl.python import builder
 from ftl.python import layer_builder
@@ -57,8 +58,12 @@ class PythonTest(unittest.TestCase):
         args.venv_cmd = 'virtualenv'
         args.tar_base_image_path = None
         self.builder = builder.Python(self.ctx, args)
+
+        # constants.VENV_DIR.replace('/', '') is used as the default path
+        # will give permissions errors in some build environments (eg: kokoro)
         self.interpreter_builder = layer_builder.InterpreterLayerBuilder(
-            self.builder._venv_dir, self.builder._python_cmd,
+            ftl_util.gen_tmp_dir(constants.VENV_DIR.replace('/', '')),
+            self.builder._python_cmd,
             self.builder._venv_cmd)
         self.interpreter_builder._setup_venv = mock.Mock()
         self.builder._pip_install = mock.Mock()

--- a/ftl/python/testdata/packages_test/structure_test.yaml
+++ b/ftl/python/testdata/packages_test/structure_test.yaml
@@ -16,3 +16,9 @@ fileExistenceTests:
   path: '/env/lib/python2.7/site-packages/flask'
   shouldExist: true
   isDirectory: false
+
+commandTests:
+- name: 'venv setup correctly'
+  command: 'cat'
+  args: ['/env/bin/activate']
+  expectedOutput: ['"/env"']


### PR DESCRIPTION
fixes the issue where the path for the venv was incorrect in /env/bin/activate as the directory was moved the way it was being built.  now the dir is not moved