### PR TITLE
Change default machine type from 32CPU to 8CPU.

### DIFF
--- a/versioning/scripts/cloudbuild/main.go
+++ b/versioning/scripts/cloudbuild/main.go
@@ -138,7 +138,7 @@ timeout: {{ .TimeoutSeconds }}s
 
 {{- if $parallel }}
 options:
-  machineType: 'N1_HIGHCPU_32'
+  machineType: 'N1_HIGHCPU_8'
 {{- end }}
 `
 


### PR DESCRIPTION
Usually there is no need to use 32 CPUs and such a VM is very expensive. 