### PR TITLE
Add FuncMap to Templates and validate them

### DIFF
--- a/ctc_lib/BUILD.bazel
+++ b/ctc_lib/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "config_command_test.go",
         "container_tool_command_test.go",
         "container_tool_list_command_test.go",
+        "template_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],

--- a/ctc_lib/cli_interface.go
+++ b/ctc_lib/cli_interface.go
@@ -33,7 +33,7 @@ import (
 
 type CLIInterface interface {
 	printO(c *cobra.Command, args []string) error
-	setRun(func(c *cobra.Command, args []string))
+	setRunE(func(c *cobra.Command, args []string) error)
 	getCommand() *cobra.Command
 	ValidateCommand() error
 	isRunODefined() bool
@@ -53,13 +53,11 @@ func ExecuteE(ctb CLIInterface) (err error) {
 	}
 	ctb.Init()
 	if ctb.isRunODefined() {
-		cobraRun := func(c *cobra.Command, args []string) {
+		cobraRunE := func(c *cobra.Command, args []string) error {
 			err = ctb.printO(c, args)
-			if err != nil {
-				Log.Error(err)
-			}
+			return err
 		}
-		ctb.setRun(cobraRun)
+		ctb.setRunE(cobraRunE)
 	}
 
 	err = ctb.getCommand().Execute()

--- a/ctc_lib/container_tool_command.go
+++ b/ctc_lib/container_tool_command.go
@@ -46,5 +46,5 @@ func (ctc *ContainerToolCommand) printO(c *cobra.Command, args []string) error {
 	obj, _ := ctc.RunO(c, args)
 	ctc.Output = obj
 	return util.ExecuteTemplate(ctc.ReadTemplateFromFlagOrCmdDefault(),
-		ctc.Output, ctc.OutOrStdout())
+		ctc.Output, ctc.TemplateFuncMap, ctc.OutOrStdout())
 }

--- a/ctc_lib/container_tool_command_base.go
+++ b/ctc_lib/container_tool_command_base.go
@@ -17,6 +17,8 @@ limitations under the License.
 package ctc_lib
 
 import (
+	"text/template"
+
 	"github.com/GoogleCloudPlatform/runtimes-common/ctc_lib/config"
 	"github.com/GoogleCloudPlatform/runtimes-common/ctc_lib/constants"
 	"github.com/GoogleCloudPlatform/runtimes-common/ctc_lib/flags"
@@ -29,15 +31,16 @@ import (
 type ContainerToolCommandBase struct {
 	*cobra.Command
 	Phase           string
-	DefaultTemplate string
+	DefaultTemplate string //TODO: Validate Default Config.
+	TemplateFuncMap template.FuncMap
 }
 
 func (ctb *ContainerToolCommandBase) getCommand() *cobra.Command {
 	return ctb.Command
 }
 
-func (ctb *ContainerToolCommandBase) setRun(cobraRun func(c *cobra.Command, args []string)) {
-	ctb.Run = cobraRun
+func (ctb *ContainerToolCommandBase) setRunE(cobraRunE func(c *cobra.Command, args []string) error) {
+	ctb.RunE = cobraRunE
 }
 
 func (ctb *ContainerToolCommandBase) toolName() string {
@@ -74,10 +77,10 @@ func (ctb *ContainerToolCommandBase) AddSubCommands() {
 }
 
 func (ctb *ContainerToolCommandBase) AddCommand(command CLIInterface) {
-	cobraRun := func(c *cobra.Command, args []string) {
-		command.printO(c, args)
+	cobraRunE := func(c *cobra.Command, args []string) error {
+		return command.printO(c, args)
 	}
-	command.setRun(cobraRun)
+	command.setRunE(cobraRunE)
 	ctb.Command.AddCommand(command.getCommand())
 }
 

--- a/ctc_lib/container_tool_list_command.go
+++ b/ctc_lib/container_tool_list_command.go
@@ -46,5 +46,5 @@ func (ctc *ContainerToolListCommand) printO(c *cobra.Command, args []string) err
 	obj, _ := ctc.RunO(c, args)
 	ctc.OutputList = obj
 	return util.ExecuteTemplate(ctc.ReadTemplateFromFlagOrCmdDefault(),
-		ctc.OutputList, ctc.OutOrStdout())
+		ctc.OutputList, ctc.TemplateFuncMap, ctc.OutOrStdout())
 }

--- a/ctc_lib/template_test.go
+++ b/ctc_lib/template_test.go
@@ -80,3 +80,24 @@ func TestContainerToolTestOutputWithFuncTemplate(t *testing.T) {
 		t.Errorf("Expected to contain: \n HELLO WORLD! \nGot:\n %v\n", OutputBuffer.String())
 	}
 }
+
+func TestContainerToolTestOutputWithNilFuncMap(t *testing.T) {
+	testCommand := ContainerToolCommand{
+		ContainerToolCommandBase: &ContainerToolCommandBase{
+			Command: &cobra.Command{
+				Use: "Hello Command",
+			},
+			Phase:           "test",
+			DefaultTemplate: "{{.Greeting}} {{.Name}}!",
+			TemplateFuncMap: nil,
+		},
+		Output: &TestInterface{},
+		RunO:   RunTemplateCommand,
+	}
+	var OutputBuffer bytes.Buffer
+	testCommand.Command.SetOutput(&OutputBuffer)
+	Execute(&testCommand)
+	if OutputBuffer.String() != "hello world!\n" {
+		t.Errorf("Expected to contain: \n hello world! \nGot:\n %v\n", OutputBuffer.String())
+	}
+}

--- a/ctc_lib/template_test.go
+++ b/ctc_lib/template_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ctc_lib
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+type TemplateTestResult struct {
+	Greeting string
+	Name     string
+}
+
+func RunTemplateCommand(command *cobra.Command, args []string) (interface{}, error) {
+	testOutput := TestInterface{
+		Greeting: "hello",
+		Name:     "world",
+	}
+	return testOutput, nil
+}
+
+func TestContainerToolIncorrectTemplate(t *testing.T) {
+	defer SetExitOnError(true)
+	testCommand := ContainerToolCommand{
+		ContainerToolCommandBase: &ContainerToolCommandBase{
+			Command: &cobra.Command{
+				Use: "Hello Command",
+			},
+			Phase:           "test",
+			DefaultTemplate: "{{.greet}}",
+		},
+		Output: &TestInterface{},
+		RunO:   RunTemplateCommand,
+	}
+	SetExitOnError(false)
+	err := ExecuteE(&testCommand)
+	expectedError := ("can't evaluate field greet in type ctc_lib.TestInterface")
+	if !strings.Contains(err.Error(), expectedError) {
+		t.Errorf("Expected Error to contain: \n %q \nGot:\n %q\n", expectedError, err.Error())
+	}
+}
+
+func TestContainerToolTestOutputWithFuncTemplate(t *testing.T) {
+	testCommand := ContainerToolCommand{
+		ContainerToolCommandBase: &ContainerToolCommandBase{
+			Command: &cobra.Command{
+				Use: "Hello Command",
+			},
+			Phase:           "test",
+			DefaultTemplate: "{{toUpper .Greeting}} {{toUpper .Name}}!",
+			TemplateFuncMap: template.FuncMap{
+				"toUpper": strings.ToUpper,
+			},
+		},
+		Output: &TestInterface{},
+		RunO:   RunTemplateCommand,
+	}
+	var OutputBuffer bytes.Buffer
+	testCommand.Command.SetOutput(&OutputBuffer)
+	Execute(&testCommand)
+	if OutputBuffer.String() != "HELLO WORLD!\n" {
+		t.Errorf("Expected to contain: \n HELLO WORLD! \nGot:\n %v\n", OutputBuffer.String())
+	}
+}

--- a/ctc_lib/util/util.go
+++ b/ctc_lib/util/util.go
@@ -25,8 +25,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func ExecuteTemplate(templateStr string, obj interface{}, out io.Writer) error {
-	tmpl, err := template.New("Template").Parse(templateStr)
+func ExecuteTemplate(templateStr string, obj interface{}, funcMap template.FuncMap, out io.Writer) error {
+	tmpl, err := template.New("Template").Funcs(funcMap).Parse(templateStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Also change all cobra.Run to cobra.RunE so any errors when parsing and executing templates are propagated to ctc_lib.Execute() entry point.