### PR TITLE
Temporarily remove shellcheck from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,8 @@ addons:
     sources:
     - sourceline: 'deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8'
       key_url: 'https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg'
-    - debian-sid
 
     packages:
-    - shellcheck
     - bazel
 
 install:


### PR DESCRIPTION
Removing shellcheck from travis until https://github.com/travis-ci/travis-ci/issues/9484 is fixed