### PR TITLE
Add util method for parsing log entries

### DIFF
--- a/ftl/BUILD
+++ b/ftl/BUILD
@@ -63,6 +63,14 @@ py_test(
 )
 
 py_test(
+    name = "util_test",
+    srcs = ["common/util_test.py"],
+    deps = [
+        ":ftl_lib",
+    ],
+)
+
+py_test(
     name = "node_builder_test",
     srcs = ["node/builder_test.py"],
     data =

--- a/ftl/common/logger.py
+++ b/ftl/common/logger.py
@@ -14,7 +14,7 @@
 """This package defines the shared cli args for ftl binaries."""
 
 import logging
-from ftl.common import constants
+import constants
 
 LEVEL_MAP = {
     "NOTSET": logging.NOTSET,
@@ -26,8 +26,8 @@ LEVEL_MAP = {
 }
 
 
-def setup_logging(args):
-    logging.getLogger().setLevel(LEVEL_MAP[args.verbosity])
+def setup_logging(verbosity):
+    logging.getLogger().setLevel(LEVEL_MAP[verbosity])
     logging.basicConfig(
         format='%(levelname)-8s %(message)s',
         datefmt='')

--- a/ftl/common/util_test.py
+++ b/ftl/common/util_test.py
@@ -1,0 +1,85 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ftl_util"""
+
+import unittest
+import constants
+import StringIO
+import logging
+
+import ftl_util
+import logger
+
+
+class UtilTest(unittest.TestCase):
+    def setUp(self):
+        logger.setup_logging("DEBUG")
+        defaultLogger = logging.getLogger()
+
+        self.log_capture_string = StringIO.StringIO()
+        ch = logging.StreamHandler(self.log_capture_string)
+        ch.setLevel(logging.DEBUG)
+
+        defaultLogger.addHandler(ch)
+
+    def test_parse_phase1_entry(self):
+        language = 'PYTHON'
+        key = 'test key'
+        phase_1_entry = constants.PHASE_1_CACHE_HIT.format(
+            key_version=constants.CACHE_KEY_VERSION,
+            language=language,
+            key=key
+        )
+
+        logging.info(phase_1_entry)
+        entry = self.log_capture_string.getvalue()
+        log_pieces = ftl_util.parseCacheLogEntry(entry)
+        print log_pieces
+
+        self.assertEqual(log_pieces['key'], key)
+        self.assertEqual(log_pieces['language'], language)
+
+    def test_parse_phase2_entry(self):
+        language = 'PYTHON'
+        package = 'flask'
+        version = '==0.12.0'
+        key = 'test key'
+        phase_2_entry = constants.PHASE_2_CACHE_HIT.format(
+            key_version=constants.CACHE_KEY_VERSION,
+            language=language,
+            package_name=package,
+            package_version=version,
+            key=key
+        )
+
+        logging.info(phase_2_entry)
+        entry = self.log_capture_string.getvalue()
+        log_pieces = ftl_util.parseCacheLogEntry(entry)
+        print log_pieces
+
+        self.assertEqual(log_pieces['key'], key)
+        self.assertEqual(log_pieces['language'], language)
+        self.assertEqual(log_pieces['package'], package)
+        self.assertEqual(log_pieces['version'], version)
+
+    def test_parse_bad_entry(self):
+        logging.info('a malfomed, non-cache log entry')
+        entry = self.log_capture_string.getvalue()
+        log_pieces = ftl_util.parseCacheLogEntry(entry)
+
+        self.assertEqual(log_pieces, None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ftl/node/main.py
+++ b/ftl/node/main.py
@@ -36,7 +36,7 @@ args.extra_args(node_parser, args.node_flgs)
 
 def main(cli_args):
     builder_args = node_parser.parse_args(cli_args)
-    logger.setup_logging(builder_args)
+    logger.setup_logging(builder_args.verbosity)
     logger.preamble("node", builder_args)
     with ftl_util.Timing("full build"):
         with ftl_util.Timing("builder initialization"):

--- a/ftl/php/main.py
+++ b/ftl/php/main.py
@@ -35,7 +35,7 @@ args.extra_args(php_parser, args.php_flgs)
 
 def main(cli_args):
     builder_args = php_parser.parse_args(cli_args)
-    logger.setup_logging(builder_args)
+    logger.setup_logging(builder_args.verbosity)
     logger.preamble("php", builder_args)
     with ftl_util.Timing("full build"):
         with ftl_util.Timing("builder initialization"):

--- a/ftl/python/main.py
+++ b/ftl/python/main.py
@@ -35,7 +35,7 @@ args.extra_args(python_parser, args.python_flgs)
 
 def main(cli_args):
     builder_args = python_parser.parse_args(cli_args)
-    logger.setup_logging(builder_args)
+    logger.setup_logging(builder_args.verbosity)
     logger.preamble("python", builder_args)
     with ftl_util.Timing("full build"):
         with ftl_util.Timing("builder initialization"):


### PR DESCRIPTION
This couples the log parsing with the FTL common code, so if we change the log formatter we won't have to worry about changing consumer code.