### PR TITLE
Fix for thread unsafe strptime

### DIFF
--- a/ftl/common/builder.py
+++ b/ftl/common/builder.py
@@ -35,6 +35,7 @@ from ftl.common import ftl_util
 # See http://bugs.python.org/issue7980
 datetime.datetime.strptime('', '')
 
+
 class Base(object):
     """Base is an abstract base class representing a container builder.
     It provides methods for generating runtime layers and an application

--- a/ftl/common/builder.py
+++ b/ftl/common/builder.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import abc
+import datetime
 import tarfile
 import logging
 import httplib2
@@ -28,6 +29,11 @@ from ftl.common import cache
 from ftl.common import constants
 from ftl.common import ftl_util
 
+# Do not Remove. Fix for strptime not being thread safe.
+# Initialize datetime in the base class RuntimeBase. The Build calls
+# datetime.datetime.strptime in threads.
+# See http://bugs.python.org/issue7980
+datetime.datetime.strptime('', '')
 
 class Base(object):
     """Base is an abstract base class representing a container builder.


### PR DESCRIPTION
Our kokoro Int tests have been failing intermittently due to 
""AttributeError: 'module' object has no attribute '_strptime''

This is because datetime.datetime.strptime is not thread safe.
As per the discussions in various thread, (https://mail.python.org/pipermail/python-list/2015-October/697689.html) and more,  the fixes are
1. make an initial call to datetime.datetime.strptime before threading 
2. Another approach is to import _strptime where its called

I am using the first approach which has been successful in other projects.
Example:
https://github.com/boto/boto/pull/1940