### PR TITLE
Initialize logging with default info

### DIFF
--- a/ctc_lib/container_tool_command_base.go
+++ b/ctc_lib/container_tool_command_base.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/runtimes-common/ctc_lib/flags"
 	"github.com/GoogleCloudPlatform/runtimes-common/ctc_lib/logging"
 	"github.com/GoogleCloudPlatform/runtimes-common/ctc_lib/types"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -50,6 +51,14 @@ func (ctb *ContainerToolCommandBase) toolName() string {
 }
 
 func (ctb *ContainerToolCommandBase) Init() {
+	// Init Logging with info level with colors disabled since initLogging gets called
+	// only after arguments are parsed correctly.
+	Log = logging.NewLogger(
+		viper.GetString(config.LogDirConfigKey),
+		ctb.Name(),
+		log.InfoLevel,
+		false,
+	)
 	cobra.OnInitialize(initConfig, ctb.initLogging)
 	ctb.AddFlags()
 	ctb.AddSubCommands()

--- a/ctc_lib/container_tool_command_base.go
+++ b/ctc_lib/container_tool_command_base.go
@@ -59,9 +59,15 @@ func (ctb *ContainerToolCommandBase) Init() {
 		log.InfoLevel,
 		false,
 	)
-	cobra.OnInitialize(initConfig, ctb.initLogging)
+	cobra.OnInitialize(initConfig, ctb.initLogging, ctb.SetSilenceUsage)
 	ctb.AddFlags()
 	ctb.AddSubCommands()
+}
+
+func (ctb *ContainerToolCommandBase) SetSilenceUsage() {
+	// Donot display usage when using RunE after args are parsed.
+	// See https://github.com/spf13/cobra/issues/340 for more information.
+	ctb.SilenceUsage = true
 }
 
 func (ctb *ContainerToolCommandBase) initLogging() {
@@ -85,10 +91,6 @@ func (ctb *ContainerToolCommandBase) AddSubCommands() {
 
 	// Set up Root Command
 	ctb.Command.SetHelpTemplate(HelpTemplate)
-
-	// Donot display usage when using RunE.
-	// See https://github.com/spf13/cobra/issues/340 for more information.
-	ctb.SilenceUsage = true
 }
 
 func (ctb *ContainerToolCommandBase) AddCommand(command CLIInterface) {

--- a/ctc_lib/container_tool_command_base.go
+++ b/ctc_lib/container_tool_command_base.go
@@ -65,7 +65,7 @@ func (ctb *ContainerToolCommandBase) Init() {
 }
 
 func (ctb *ContainerToolCommandBase) SetSilenceUsage() {
-	// Donot display usage when using RunE after args are parsed.
+	// Do not display usage when using RunE after args are parsed.
 	// See https://github.com/spf13/cobra/issues/340 for more information.
 	ctb.SilenceUsage = true
 }

--- a/ctc_lib/container_tool_command_test.go
+++ b/ctc_lib/container_tool_command_test.go
@@ -263,3 +263,31 @@ func TestContainerToolCommandOutputInJson(t *testing.T) {
 		t.Errorf("Expected to contain: \n %v\nGot:\n %v\n", expectedObj, actualObj)
 	}
 }
+
+func TestContainerToolCommandLogNotNull(t *testing.T) {
+	defer SetExitOnError(true)
+	testCommand := ContainerToolCommand{
+		ContainerToolCommandBase: &ContainerToolCommandBase{
+			Command: &cobra.Command{
+				Use:   "loggingError",
+				Short: "Logging not nil",
+			},
+		},
+		Output: "",
+		RunO: func(command *cobra.Command, args []string) (interface{}, error) {
+			return nil, nil
+		},
+	}
+	SetExitOnError(false)
+	var OutputBuffer bytes.Buffer
+	testCommand.Command.SetOutput(&OutputBuffer)
+	testCommand.SetArgs([]string{"--name=Sparks"})
+	err := ExecuteE(&testCommand)
+	expectedError := ("unknown flag: --name")
+	if Log == nil {
+		t.Errorf("Expected Log to be not nil. Got nil")
+	}
+	if err.Error() != expectedError {
+		t.Errorf("Expected Error: \n %q \nGot:\n %q\n", expectedError, err.Error())
+	}
+}

--- a/ctc_lib/container_tool_command_test.go
+++ b/ctc_lib/container_tool_command_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -286,6 +287,35 @@ func TestContainerToolCommandLogNotNull(t *testing.T) {
 	expectedError := ("unknown flag: --name")
 	if Log == nil {
 		t.Errorf("Expected Log to be not nil. Got nil")
+	}
+	if !strings.Contains(OutputBuffer.String(), "Usage:") {
+		t.Error("Expected to contain Usage. However Usage is not displayed")
+	}
+	if err.Error() != expectedError {
+		t.Errorf("Expected Error: \n %q \nGot:\n %q\n", expectedError, err.Error())
+	}
+}
+
+func TestContainerToolCommandDoesNotDisplayUsage(t *testing.T) {
+	defer SetExitOnError(true)
+	testCommand := ContainerToolCommand{
+		ContainerToolCommandBase: &ContainerToolCommandBase{
+			Command: &cobra.Command{
+				Use: "fail Command",
+			},
+		},
+		Output: "",
+		RunO: func(command *cobra.Command, args []string) (interface{}, error) {
+			return nil, errors.New("Command failed")
+		},
+	}
+	SetExitOnError(false)
+	var OutputBuffer bytes.Buffer
+	testCommand.Command.SetOutput(&OutputBuffer)
+	err := ExecuteE(&testCommand)
+	expectedError := ("Command failed")
+	if strings.Contains(OutputBuffer.String(), "Usage:") {
+		t.Error("Expected to not display usage when Command Fails. However Usage is displayed")
 	}
 	if err.Error() != expectedError {
 		t.Errorf("Expected Error: \n %q \nGot:\n %q\n", expectedError, err.Error())


### PR DESCRIPTION
In c-s-t  we are seeing errors https://github.com/GoogleContainerTools//issues/135
```
/bazel-bin/linux_amd64_pure_stripped/container_structure_test  --image gcr.io/google-appengine/debian8 --config tests/debian_failure_test.yaml  -verbose=debug

ERRO[0000] runtime error: invalid memory address or nil pointer dereference 
tejaldesai@tejaldesai~/go/src/github.com/GoogleContainerTools/container-structure-test: (fix_invalid_flags)$ 
```

This is because,  we --image is not a valid arg for root command container_structure_test. The conbra.OnInitialize registered function initLogging is only called when the command is parsed correctly.
Hence, this diff initialize the logging with info log level.
