### PR TITLE
Update documentation URLs

### DIFF
--- a/docgen/lib/render/templates/README.md.tmpl
+++ b/docgen/lib/render/templates/README.md.tmpl
@@ -616,7 +616,7 @@ Dockerfile for this image can be found [here]({{.Overview.DockerfileUrl}}).
 
 # <a name="using-kubernetes"></a>Using Kubernetes
 
-Consult [Launcher container documentation](https://cloud.google.com/launcher/docs/launcher-container)
+Consult [Marketplace container documentation](https://cloud.google.com/marketplace/docs/marketplace-container)
 for additional information about setting up your Kubernetes environment.
 
 {{- template "taskgroups" .KubernetesTaskGroups}}
@@ -627,7 +627,7 @@ for additional information about setting up your Kubernetes environment.
 
 # <a name="using-docker"></a>Using Docker
 
-Consult [Launcher container documentation](https://cloud.google.com/launcher/docs/launcher-container)
+Consult [Marketplace container documentation](https://cloud.google.com/marketplace/docs/marketplace-container)
 for additional information about setting up your Docker environment.
 
 {{- template "taskgroups" .DockerTaskGroups}}


### PR DESCRIPTION
Updating documentation URLs due to Marketplace rebranding.
https://cloud.google.com/launcher/docs/launcher-container would redirect to https://cloud.google.com/marketplace/docs/launcher-container, serving a 404. 

The new URL is https://cloud.google.com/marketplace/docs/marketplace-container