### PR TITLE
Adds a flag 'skip_package_lock_generation' to FTL

### DIFF
--- a/ftl/BUILD
+++ b/ftl/BUILD
@@ -68,6 +68,7 @@ py_test(
     srcs = ["common/util_test.py"],
     deps = [
         ":ftl_lib",
+        "@mock",
     ],
 )
 

--- a/ftl/common/args.py
+++ b/ftl/common/args.py
@@ -99,6 +99,12 @@ def base_parser():
         action='store_true',
         help='Upload to cache during build (default).')
     parser.add_argument(
+        '--skip_package_lock_generation',
+        dest='skip_package_lock_gen',
+        default=False,
+        action='store_true',
+        help='Do not create package lock file before checking cache.')
+    parser.add_argument(
         '--output-path',
         dest='output_path',
         action='store',

--- a/ftl/node/builder.py
+++ b/ftl/node/builder.py
@@ -34,6 +34,8 @@ class Node(builder.RuntimeBase):
         self._should_use_yarn = self._should_use_yarn(self._ctx)
 
     def _gen_package_lock_if_required(self, ctx):
+        if self._args.skip_package_lock_gen:
+            return
         if not ftl_util.has_pkg_descriptor(self._descriptor_files, self._ctx):
             return
 
@@ -76,6 +78,7 @@ class Node(builder.RuntimeBase):
                 directory=self._args.directory,
                 destination_path=self._args.destination_path,
                 should_use_yarn=self._should_use_yarn,
+                reuse_cache_key=self._args.skip_package_lock_gen,
                 cache_key_version=self._args.cache_key_version,
                 cache=self._cache)
             layer_builder.BuildLayer()

--- a/ftl/node/layer_builder.py
+++ b/ftl/node/layer_builder.py
@@ -32,6 +32,7 @@ class LayerBuilder(single_layer_image.CacheableLayerBuilder):
                  directory=None,
                  destination_path=constants.DEFAULT_DESTINATION_PATH,
                  should_use_yarn=None,
+                 reuse_cache_key=False,
                  cache_key_version=None,
                  cache=None):
         super(LayerBuilder, self).__init__()
@@ -41,14 +42,17 @@ class LayerBuilder(single_layer_image.CacheableLayerBuilder):
         self._directory = directory
         self._destination_path = destination_path
         self._should_use_yarn = should_use_yarn
+        self._reuse_cache_key = reuse_cache_key
         self._cache_key_version = cache_key_version
         self._cache = cache
+        self._cache_key = None
 
     def GetCacheKeyRaw(self):
-        all_descriptor_contents = ftl_util.all_descriptor_contents(
-            self._descriptor_files, self._ctx)
-        cache_key = '%s %s' % (all_descriptor_contents, self._destination_path)
-        return "%s %s" % (cache_key, self._cache_key_version)
+        if not self._cache_key or not self._reuse_cache_key:
+            all_descriptor_contents = ftl_util.all_descriptor_contents(
+                self._descriptor_files, self._ctx)
+            self._cache_key = '%s %s' % (all_descriptor_contents, self._destination_path)
+        return "%s %s" % (self._cache_key, self._cache_key_version)
 
     def BuildLayer(self):
         """Override."""


### PR DESCRIPTION
Adds a flag 'skip_package_lock_generation' to control if FTL should generate package-lock file at the beginning of the run. Skiping this can improve build speed but can cause older version of dependencies to be used.
