### PR TITLE
Make deploy_check actually report errors

### DIFF
--- a/appengine/integration_tests/deploy_check.py
+++ b/appengine/integration_tests/deploy_check.py
@@ -93,6 +93,7 @@ def _deploy_and_test(appdir, language, is_xrt):
         _test_application(application_url)
     except Exception as e:
         logging.error('Error when contacting application: %s', e)
+        sys.exit(1)
     finally:
         if version:
             deploy_app.stop_version(version)


### PR DESCRIPTION
When an error happens when deploying an app or testing the deployed app, `deploy_check.py` logs the error but does not actually return an error code. As a result CI (Kokoro) always reports success even if an error happens. This should fix that issue.