### PR TITLE
Make openjdk and jetty show up as the java runtime to clarify output

### DIFF
--- a/appengine/reconciletags/version_check_test.py
+++ b/appengine/reconciletags/version_check_test.py
@@ -208,6 +208,8 @@ class VersionCheckTest(unittest.TestCase):
                                 }
                                 old_images.append(entry)
                 if old_images:
+                    if runtime == 'jetty' or runtime == 'openjdk':
+                        runtime = 'java'
                     images_map[runtime] = old_images
 
         if images_map:


### PR DESCRIPTION
The bug I'm fixing was introduced in #773. 

The file we're parsing for both openjdk and jetty is called java.json, but we need to check them entirely separately, so I reuse the runtime variable to filter on the proper runtime. 

Once we're done checking and aggregate our finding, I want them both back under the "java" heading, so this is just me changing it back.
