### PR TITLE
Propagate env vars to sudo invocations.

### DIFF
--- a/appengine/runtime_builders/template_builder.sh
+++ b/appengine/runtime_builders/template_builder.sh
@@ -11,5 +11,5 @@ fi
 source "$KOKORO_GFILE_DIR/common.sh"
 
 cd github
-yes | sudo pip3 install ruamel.yaml
+yes | sudo -E pip3 install ruamel.yaml
 python3 runtimes-common/appengine/runtime_builders/template_builder.py -f "${KOKORO_GFILE_DIR}/${CONFIG_FILE}"


### PR DESCRIPTION
From the sudo man page:

```
     -E, --preserve-env
                 Indicates to the security policy that the user wishes to preserve their existing environment
                 variables.  The security policy may return an error if the user does not have permission to
                 preserve the environment.
```