### PR TITLE
Update pause with Docker Schema 2 image

### DIFF
--- a/appengine/reconciletags/e2e_cloudbuild.yaml
+++ b/appengine/reconciletags/e2e_cloudbuild.yaml
@@ -1,7 +1,7 @@
 #Pull and tag a simple docker image for retagger e2e test
 steps:
   - name:  'gcr.io/cloud-builders/docker'
-    args: ['pull', 'gcr.io/google-containers/pause:3.0']
+    args: ['pull', 'registry.k8s.io/pause:3.8']
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['tag', 'gcr.io/google-containers/pause:3.0', 'gcr.io/gcp-runtimes/reconciler-e2etest:initial']
+    args: ['tag', 'registry.k8s.io/pause:3.8', 'gcr.io/gcp-runtimes/reconciler-e2etest:initial']
 images: ['gcr.io/gcp-runtimes/reconciler-e2etest:initial']

--- a/appengine/reconciletags/tiny_docker_image/Dockerfile
+++ b/appengine/reconciletags/tiny_docker_image/Dockerfile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 # This builds a non-functional, but very tiny docker image.
-FROM gcr.io/google-containers/pause:3.0
+FROM registry.k8s.io/pause:3.8


### PR DESCRIPTION
Docker Schema 1 images are deprecated and support is [removed in containerd 2.0](https://containerd.io/releases/#deprecated-features). These workloads need updating in order to continue working.

Verified image schemas via:
```sh
$ crane manifest gcr.io/google-containers/pause:3.0 | jq .schemaVersion
1

$ crane manifest registry.k8s.io/pause:3.8 | jq .schemaVersion
2
```

**NOTE:** This isn't totally necessary since the files here are for building new container images, and modern image builders will not use Docker Schema 1, but this is just a precaution.