### PR TITLE
Remove references to the uncalimed GCS bucket 'ftl-global-cache' 

### DIFF
--- a/ftl/cache_cloudbuild.yaml
+++ b/ftl/cache_cloudbuild.yaml
@@ -9,4 +9,4 @@ steps:
 
   - name: gcr.io/cloud-builders/gsutil
     args: ['cp', '/workspace/${LANGUAGE}-mapping.json',
-           'gs://ftl-global-cache/${LANGUAGE}-mapping.json']
+           'gs://ftl-global-cache-1/${LANGUAGE}-mapping.json']

--- a/ftl/common/cache_runner.py
+++ b/ftl/common/cache_runner.py
@@ -40,7 +40,7 @@ LANGUAGE_CACHES = {
     PYTHON: constants.PYTHON_CACHE_NAMESPACE
 }
 
-MAPPING_BUCKET = 'ftl-global-cache'
+MAPPING_BUCKET = 'ftl-global-cache-1'
 MAPPING_FILE = '{language}-mapping.json'
 LOCAL_MAPPING_FILE = '/workspace/' + MAPPING_FILE
 


### PR DESCRIPTION
The replaced bucket 'ftl-global-cache-1' is a google owned bucket.