### PR TITLE
fix: prevent PyPI resolution for error_test fixture (dependency confusion)

### DIFF
--- a/ftl/python/testdata/error_test/requirements.txt
+++ b/ftl/python/testdata/error_test/requirements.txt
@@ -1,1 +1,4 @@
+# This file is a test fixture that intentionally references a non-existent package.
+# Do not install with pip — use --no-index to prevent PyPI resolution.
+--no-index
 floogle


### PR DESCRIPTION
`ftl/python/testdata/error_test/requirements.txt` contains a single entry, `floogle`, which is not registered on PyPI. The file is an error-handling test fixture, so a non-existent package name is intentional — but without any index restriction, pip will query PyPI for it.

An attacker who registers `floogle` on PyPI would have it installed whenever a developer or CI pipeline runs `pip install -r` against this fixture.

This PR adds `--no-index` to the file so that pip cannot resolve the package from PyPI, preserving the test intent while eliminating the squatting risk.
